### PR TITLE
Auto-pause game while menu is open

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,12 +53,28 @@
 			}
 		},
 		{
-			"name": "ALL",
+			"name": "SE/AE",
 			"cacheVariables": {
 				"BUILD_SKYRIM": true,
 				"ENABLE_SKYRIM_AE": "ON",
 				"ENABLE_SKYRIM_SE": "ON",
-				"ENABLE_SKYRIM_VR": "ON",
+				"ENABLE_SKYRIM_VR": "OFF",
+				"AUTO_PLUGIN_DEPLOYMENT": "ON"
+			},
+			"inherits": [
+				"common",
+				"vcpkg",
+				"win64",
+				"msvc"
+			]
+		},
+		{
+			"name": "VR",
+			"cacheVariables": {
+				"BUILD_SKYRIM": true,
+				"ENABLE_SKYRIM_AE": "ON",
+				"ENABLE_SKYRIM_SE": "ON",
+				"ENABLE_SKYRIM_VR": "OFF",
 				"AUTO_PLUGIN_DEPLOYMENT": "ON"
 			},
 			"inherits": [

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -7,6 +7,31 @@
 
 namespace Modex
 {
+
+	void Menu::Open()
+	{
+		enable = true;
+
+		if (Settings::GetSingleton()->GetConfig().pauseGame) {
+			RE::PlayerCharacter::GetSingleton()->SetPlayerControls(false);
+			RE::Main::GetSingleton()->freezeTime = true;
+		}
+	}
+
+	void Menu::Close()
+	{
+		enable = false;
+
+		if (Settings::GetSingleton()->GetConfig().pauseGame) {
+			if (const auto& overrideData = RE::ImageSpaceManager::GetSingleton()->overrideBaseData) {
+				overrideData->cinematic.brightness = 1.0f;
+			}
+
+			RE::PlayerCharacter::GetSingleton()->SetPlayerControls(true);
+			RE::Main::GetSingleton()->freezeTime = false;
+		}
+	}
+
 	void Menu::Draw()
 	{
 		// TODO: Maybe hook this into an update call?
@@ -27,9 +52,7 @@ namespace Modex
 			ImGui::GetIO().MouseDrawCursor = false;
 		}
 
-		Settings::Style& style = Settings::GetSingleton()->GetStyle();
-
-		ImGui::PushFont(style.font.normal);
+		ImGui::PushFont(Settings::GetSingleton()->GetStyle().font.normal);
 		Frame::Draw(is_settings_popped);
 		ImGui::PopFont();
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -17,9 +17,19 @@ namespace Modex
 		bool IsEnabled() { return enable; }
 		void SetEnabled(bool value) { enable = value; }
 
-		constexpr void Toggle() { enable = !enable; }
-		constexpr void Close() { enable = false; }
-		constexpr void Open() { enable = true; }
+		void Open();
+		void Close();
+
+		constexpr void Toggle()
+		{
+			if (enable) {
+				Close();
+			} else {
+				Open();
+			}
+		}
+
+		float prevGlobalTimeMultiplier;
 
 		static inline Menu* GetSingleton()
 		{

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -97,6 +97,7 @@ namespace Modex
 			a_ini.SetValue(rSections[Main], "Language", "English");
 			a_ini.SetValue(rSections[Main], "ModListSort", "0");
 			a_ini.SetValue(rSections[Main], "UI Scale", "100");
+			a_ini.SetValue(rSections[Main], "PauseGame", "false");
 
 			a_ini.SetValue(rSections[Modules], "DefaultShow", "1");
 			a_ini.SetValue(rSections[Modules], "ShowHomeMenu", "false");
@@ -163,6 +164,7 @@ namespace Modex
 			a_ini.SetValue(rSections[Main], "GlyphRange", Language::GetGlyphName(Settings::GetSingleton()->user.config.glyphRange).c_str());
 			a_ini.SetValue(rSections[Main], "ModListSort", std::to_string(Settings::GetSingleton()->user.config.modListSort).c_str());
 			a_ini.SetValue(rSections[Main], "UI Scale", std::to_string(Settings::GetSingleton()->user.config.uiScale).c_str());
+			a_ini.SetValue(rSections[Main], "PauseGame", ToString(Settings::GetSingleton()->user.config.pauseGame, false).c_str());
 
 			a_ini.SetValue(rSections[Modules], "DefaultShow", std::to_string(Settings::GetSingleton()->user.config.defaultShow).c_str());
 			a_ini.SetValue(rSections[Modules], "ShowHomeMenu", ToString(Settings::GetSingleton()->user.config.showHomeMenu, false).c_str());
@@ -187,6 +189,7 @@ namespace Modex
 		user.config.glyphRange = GET_VALUE<Language::GlyphRanges>(rSections[Main], "GlyphRange", Language::GlyphRanges::Default, a_ini);
 		user.config.modListSort = GET_VALUE<int>(rSections[Main], "ModListSort", 0, a_ini);
 		user.config.uiScale = GET_VALUE<int>(rSections[Main], "UI Scale", 100, a_ini);
+		user.config.pauseGame = GET_VALUE<bool>(rSections[Main], "PauseGame", false, a_ini);
 
 		user.config.defaultShow = GET_VALUE<int>(rSections[Modules], "DefaultShow", 0, a_ini);
 		user.config.showHomeMenu = GET_VALUE<bool>(rSections[Modules], "ShowHomeMenu", false, a_ini);

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -80,6 +80,7 @@ namespace Modex
 			Language::GlyphRanges glyphRange = Language::GlyphRanges::Default;
 			int modListSort;  // 0 = Alphabetical, 1 = Installation (WIN ONLY)
 			int uiScale;      // 80, 90, 100, 110, 120 (Should be a slider..)
+			bool pauseGame = false;
 
 			int defaultShow = 1;  // 0 = Home, 1 = AddItem, 2 = Object, 3 = NPC, 4 = Teleport, 5 = Settings
 			bool showHomeMenu = false;

--- a/src/windows/Frame.cpp
+++ b/src/windows/Frame.cpp
@@ -52,6 +52,23 @@ namespace Modex
 		const float panel_x = center_x - (window.panel_w * 0.5f) + (window.sidebar_w * 0.5f) + (style.sidebarSpacing / 2);
 		const float sidebar_x = panel_x - (window.sidebar_w) - (style.sidebarSpacing);
 
+		// Draw a transparent black overlay when the game is paused.
+		// Workaround instead of using Skyrim imagespace filters.
+		if (config.pauseGame) {
+			ImGui::SetNextWindowPos(ImVec2(0, 0));
+			ImGui::SetNextWindowSize(window.screenSize);
+			ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+			ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 0.0f);
+			ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.0f, 0.0f, 0.0f, 0.35f));
+
+			ImGui::Begin("##Background", NULL, BACKGROUND_FLAGS);
+			ImGui::End();
+
+			ImGui::PopStyleVar(2);
+			ImGui::PopStyleColor(2);
+		}
+
 		// Draw Sidebar Frame
 		static constexpr ImGuiWindowFlags sidebar_flag = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoTitleBar;
 		auto noFocus = is_settings_popped ? ImGuiWindowFlags_NoBringToFrontOnFocus : 0;

--- a/src/windows/Frame.h
+++ b/src/windows/Frame.h
@@ -60,5 +60,11 @@ namespace Modex
 		static inline constexpr auto ACTIONBAR_FLAGS =
 			ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg |
 			ImGuiTableFlags_ScrollY;
+
+		static inline constexpr auto BACKGROUND_FLAGS =
+			ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize |
+			ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar |
+			ImGuiWindowFlags_NoInputs | ImGuiWindowFlags_NoFocusOnAppearing |
+			ImGuiWindowFlags_NoBringToFrontOnFocus | ImGuiWindowFlags_NoNav;
 	};
 }

--- a/src/windows/UserSettings/UserSettings.cpp
+++ b/src/windows/UserSettings/UserSettings.cpp
@@ -521,6 +521,8 @@ namespace Modex
 		}
 		ImGui::PopItemWidth();
 
+		AddCheckbox("SETTINGS_PAUSE_GAME", config.pauseGame);
+
 		ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
 		ImGui::Unindent();
 		ImGui::SeparatorText(_TFM("SETTING_MODULE", ":"));


### PR DESCRIPTION
Fixes #13

- Added option to pause during menu.
- Added background tint when paused.
- If enabled through settings, pauses game when menu is opened.
- Split builds into SE/AE and VR.

Had to split the builds to be SE/AE and VR exclusively. Was bound to happen eventually, but in this case RE::Main has varying runtime data depending on build.