### PR TITLE
Patchu1i/issue16

### DIFF
--- a/src/Utils/Util.h
+++ b/src/Utils/Util.h
@@ -397,77 +397,92 @@ namespace Utils
 		};
 	};
 
-	inline static const char* GetArmorSlot(RE::TESObjectARMO* a_armor)
+	inline static const char* GetArmorSlotName(RE::BIPED_MODEL::BipedObjectSlot a_slot)
 	{
-		switch (a_armor->GetSlotMask()) {
+		switch (a_slot) {
 		case RE::BIPED_MODEL::BipedObjectSlot::kAmulet:
-			return "Amulet";
+			return "35 - Amulet";
 		case RE::BIPED_MODEL::BipedObjectSlot::kBody:
-			return "Body";
+			return "32 - Body";
 		case RE::BIPED_MODEL::BipedObjectSlot::kCalves:
-			return "Calves";
+			return "38 - Calves";
 		case RE::BIPED_MODEL::BipedObjectSlot::kCirclet:
-			return "Circlet";
+			return "42 - Circlet";
 		case RE::BIPED_MODEL::BipedObjectSlot::kDecapitate:
-			return "Decapitate";
+			return "51 - Decapitate";
 		case RE::BIPED_MODEL::BipedObjectSlot::kDecapitateHead:
-			return "Decapitate Head";
+			return "50 - Decapitate Head";
 		case RE::BIPED_MODEL::BipedObjectSlot::kEars:
-			return "Ears";
+			return "43 - Ears";
 		case RE::BIPED_MODEL::BipedObjectSlot::kFeet:
-			return "Feet";
+			return "37 - Feet";
 		case RE::BIPED_MODEL::BipedObjectSlot::kForearms:
-			return "Forearms";
+			return "34 - Forearms";
 		case RE::BIPED_MODEL::BipedObjectSlot::kFX01:
-			return "FX01";
+			return "61 - FX01";
 		case RE::BIPED_MODEL::BipedObjectSlot::kHair:
-			return "Hair";
+			return "31 - Hair";
 		case RE::BIPED_MODEL::BipedObjectSlot::kHands:
-			return "Hands";
+			return "33 - Hands";
 		case RE::BIPED_MODEL::BipedObjectSlot::kHead:
-			return "Head";
+			return "30 - Head";
 		case RE::BIPED_MODEL::BipedObjectSlot::kLongHair:
-			return "Long Hair";
+			return "41 - Long Hair";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModArmLeft:
-			return "Mod Arm Left";
+			return "58 - Mod Arm Left";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModArmRight:
-			return "Mod Arm Right";
+			return "59 - Mod Arm Right";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModBack:
-			return "Mod Back";
+			return "47 - Mod Back";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModChestPrimary:
-			return "Mod Chest Primary";
+			return "46 - Mod Chest Primary";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModChestSecondary:
-			return "Mod Chest Secondary";
+			return "56 - Mod Chest Secondary";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModFaceJewelry:
-			return "Mod Face Jewelry";
+			return "55 - Mod Face Jewelry";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModLegLeft:
-			return "Mod Leg Left";
+			return "54 - Mod Leg Left";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModLegRight:
-			return "Mod Leg Right";
+			return "53 - Mod Leg Right";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModMisc1:
-			return "Mod Misc1";
+			return "48 - Mod Misc1";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModMisc2:
-			return "Mod Misc2";
+			return "60 - Mod Misc2";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModMouth:
-			return "Mod Mouth";
+			return "44 - Mod Mouth";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModNeck:
-			return "Mod Neck";
+			return "45 - Mod Neck";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModPelvisPrimary:
-			return "Mod Pelvis Primary";
+			return "49 - Mod Pelvis Primary";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModPelvisSecondary:
-			return "Mod Pelvis Secondary";
+			return "52 - Mod Pelvis Secondary";
 		case RE::BIPED_MODEL::BipedObjectSlot::kModShoulder:
-			return "Mod Shoulder";
+			return "57 - Mod Shoulder";
 		case RE::BIPED_MODEL::BipedObjectSlot::kRing:
-			return "Ring";
+			return "36 - Ring";
 		case RE::BIPED_MODEL::BipedObjectSlot::kShield:
-			return "Shield";
+			return "39 - Shield";
 		case RE::BIPED_MODEL::BipedObjectSlot::kTail:
-			return "Tail";
+			return "40 - Tail";
 		default:
-			return "None";
+			return "MODEX_ERR";
 		};
 	};
+
+	inline static std::vector<std::string> GetArmorSlots(RE::TESObjectARMO* a_armor)
+	{
+		std::vector<std::string> slots;
+		auto bipedObject = a_armor->As<RE::BGSBipedObjectForm>();
+		if (bipedObject) {
+			auto slotMask = bipedObject->GetSlotMask();
+			for (int i = 0; i < 32; i++) {
+				if (static_cast<int>(slotMask) & (1 << i)) {
+					slots.push_back(GetArmorSlotName(static_cast<RE::BIPED_MODEL::BipedObjectSlot>(1 << i)));
+				}
+			}
+		}
+		return slots;
+	}
 
 	template <class T>
 	[[nodiscard]] inline static std::string GetItemDescription(RE::TESForm* form, T& a_interface = nullptr)

--- a/src/windows/AddItem/Actions.cpp
+++ b/src/windows/AddItem/Actions.cpp
@@ -74,6 +74,48 @@ namespace Modex
 		}
 		ImGui::SetDelayedTooltip(_T("AIM_PLACE_ALL_HELP"));
 
+		if (ImGui::m_Button(_T("AIM_ADD_TO_CONTAINER"), a_style, ImVec2(button_width, 0))) {
+			if (auto dataHandler = RE::TESDataHandler::GetSingleton()) {
+				auto form = RE::TESForm::LookupByID(RE::FormID(0x000D762F));
+				auto player = RE::PlayerCharacter::GetSingleton();
+
+				if (form) {
+					auto position = player->GetPosition();
+					auto angle = player->GetAngle();
+
+					// TODO: Maybe position it better?
+
+					auto objHandle = dataHandler->CreateReferenceAtLocation(
+						form->As<RE::TESBoundObject>(),  // RE::TESBoundObject* a_baseObj,
+						position,                        // const RE::NiPoint3& a_position,
+						{ 0.0f, angle.y, 0.0f },         // const RE::NiPoint3& a_rotation,
+						player->GetParentCell(),         // RE::TESObjectCELL* a_parentCell,
+						player->GetWorldspace(),         // RE::TESWorldSpace* a_worldspace,
+						nullptr,                         // RE::TESObjectREFR *a_alreadyCreatedRef,
+						nullptr,                         // RE::BGSPrimitive *a_primitive,
+						RE::ObjectRefHandle(),           // const RE::ObjectRefHandle &a_linkedRoomRefHandle,
+						false,                           // bool a_forcePersist,
+						true                             // bool a_arg11,
+					);
+
+					if (objHandle) {
+						if (auto ref = objHandle.get()) {
+							for (auto& item : itemList) {
+								RE::ExtraDataList* extraDataList = nullptr;  // ??
+
+								ref->AddObjectToContainer(
+									item->TESForm->As<RE::TESBoundObject>(),  // RE::TESBoundObject* a_item,
+									extraDataList,                            // RE::ExtraDataList* a_extraData,
+									1,                                        // std::uint32_t a_count,
+									player                                    // RE::TESObjectREFR* a_fromRefr,
+								);
+							}
+						}
+					}
+				}
+			}
+		}
+
 		ImGui::PopStyleColor(3);  // End of Secondary Buttons
 
 		ImGui::ShowWarningPopup(_T("AIM_LARGE_QUERY"), [&]() {

--- a/src/windows/ItemPreview.h
+++ b/src/windows/ItemPreview.h
@@ -49,6 +49,19 @@ namespace Modex
 			ImGui::Text(text);
 		};
 
+		const auto InlineTextMulti = [maxWidth](const char* label, std::vector<std::string> text) {
+			// const auto width = std::max(maxWidth - ImGui::CalcTextSize(text).x, ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(text[0]).x);
+			const auto width = std::max(maxWidth - ImGui::CalcTextSize(text[0].c_str()).x, ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(text[0].c_str()).x);
+			ImGui::Text(label);
+			ImGui::SameLine(width);
+			ImGui::Text(text[0].c_str());
+
+			for (int i = 1; i < text.size(); i++) {
+				ImGui::SetCursorPosX(maxWidth - ImGui::CalcTextSize(text[i].c_str()).x);
+				ImGui::Text(text[i].c_str());
+			}
+		};
+
 		const auto TruncateText = [](const char* text, const float width) -> std::string {
 			if (ImGui::CalcTextSize(text).x > width) {
 				std::string truncated = text;
@@ -109,7 +122,7 @@ namespace Modex
 				const auto armorType = Utils::GetArmorType(armor);
 				const float armorRating = Utils::CalcBaseArmorRating(armor);
 				const float armorRatingMax = Utils::CalcMaxArmorRating(armorRating, 50);
-				const auto equipSlot = Utils::GetArmorSlot(armor);
+				const auto equipSlots = Utils::GetArmorSlots(armor);
 
 				if (armorRating == 0) {
 					// InlineText("Armor Rating:", "None");
@@ -120,7 +133,7 @@ namespace Modex
 				}
 
 				InlineText(_TICONM(ICON_RPG_ARMOR, "Type", ":"), _T(armorType));
-				InlineText(_TICONM(ICON_RPG_ARMOR, "Slot", ":"), _T(equipSlot));
+				InlineTextMulti(_TICONM(ICON_RPG_ARMOR, "Slot", ":"), equipSlots);
 			}
 
 			if (a_object->GetFormType() == RE::FormType::Weapon) {


### PR DESCRIPTION
Fixes #16

Was surprisingly easy to implement this. Currently in its infant stage. Simply adds all the items in the table of AddItemMenu to a newly created chest.

Users can open console, select the chest, and "Disable" if they want to remove the chest.

Offering this as an alternative to 3D previews in the menu for now. Added a TODO element to return and better adjust the positioning of the chest.