### PR TITLE
GetArmorSlot Vector Subscript out-of-range CTD

### DIFF
--- a/src/Utils/Util.h
+++ b/src/Utils/Util.h
@@ -469,6 +469,8 @@ namespace Utils
 		};
 	};
 
+	// Returns a list of armor slots assigned to the armor.
+	// Returns "None" if no slots are assigned to prevent out-of-range access. (Issue #21)
 	inline static std::vector<std::string> GetArmorSlots(RE::TESObjectARMO* a_armor)
 	{
 		std::vector<std::string> slots;
@@ -481,6 +483,11 @@ namespace Utils
 				}
 			}
 		}
+
+		if (slots.empty()) {
+			slots.push_back("None");
+		}
+
 		return slots;
 	}
 

--- a/src/windows/ItemPreview.h
+++ b/src/windows/ItemPreview.h
@@ -50,7 +50,6 @@ namespace Modex
 		};
 
 		const auto InlineTextMulti = [maxWidth](const char* label, std::vector<std::string> text) {
-			// const auto width = std::max(maxWidth - ImGui::CalcTextSize(text).x, ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(text[0]).x);
 			const auto width = std::max(maxWidth - ImGui::CalcTextSize(text[0].c_str()).x, ImGui::GetContentRegionAvail().x - ImGui::CalcTextSize(text[0].c_str()).x);
 			ImGui::Text(label);
 			ImGui::SameLine(width);


### PR DESCRIPTION
Fixes #21

Armors with no Biped Slot Masks now return "None" inside Item Preview