### PR TITLE
Blacklist CTD

### DIFF
--- a/src/windows/UserSettings/UserSettings.cpp
+++ b/src/windows/UserSettings/UserSettings.cpp
@@ -567,7 +567,7 @@ namespace Modex
 
 		constexpr auto flags = ImGuiChildFlags_Border;
 		const float width = (ImGui::GetContentRegionAvail().x * 0.5f) - 10.0f;
-		auto modList = Data::GetSingleton()->GetModList(Data::ALL_MOD_LIST, 0);
+		auto modList = Data::GetModList(Data::ALL_MOD_LIST, 0);
 
 		ImGui::NewLine();
 
@@ -581,16 +581,12 @@ namespace Modex
 		ImGui::SeparatorEx(ImGuiSeparatorFlags_Vertical);
 		if (ImGui::BeginChild("##BlacklistLeftSide", ImVec2(width, width / 1.5f), flags)) {
 			for (auto& mod : modList) {
-				if (mod == nullptr || mod->fileName == nullptr) {
+				if (mod == nullptr || mod->GetFilename().data() == nullptr) {
 					continue;
 				}
 
 				auto& blacklist = PersistentData::GetSingleton()->m_blacklist;
 				if (!blacklist.contains(mod)) {
-					if (mod->GetFilename().empty()) {
-						continue;
-					}
-
 					if (ImGui::Selectable(mod->GetFilename().data(), false)) {
 						PersistentData::GetSingleton()->AddModToBlacklist(mod);
 					}


### PR DESCRIPTION
Fixes #19 requires verification

Crashlog points to SortModList lambda call. Previously was referencing GetFilename() string_view without null reference check.

Side note, I wonder if this has to do with mods that secretly use unique characters in their name to push them up and down in lists?