### PR TITLE
Unspecified amount of Fonts causes CTD

### DIFF
--- a/src/Data.h
+++ b/src/Data.h
@@ -58,15 +58,19 @@ namespace Modex
 
 			switch (listType) {
 			case ITEM_MOD_LIST:
-				_unsortedList = _itemModList;
+				_unsortedList.assign(_itemModList.begin(), _itemModList.end());
+				break;
 			case NPC_MOD_LIST:
-				_unsortedList = _npcModList;
+				_unsortedList.assign(_npcModList.begin(), _npcModList.end());
+				break;
 			case STATIC_MOD_LIST:
-				_unsortedList = _staticModList;
+				_unsortedList.assign(_staticModList.begin(), _staticModList.end());
+				break;
 			case CELL_MOD_LIST:
-				_unsortedList = _cellModList;
+				_unsortedList.assign(_cellModList.begin(), _cellModList.end());
+				break;
 			default:
-				_unsortedList = _modList;
+				_unsortedList.assign(_modList.begin(), _modList.end());
 			}
 
 			return SortModList(_unsortedList, sort);

--- a/src/Graphic.cpp
+++ b/src/Graphic.cpp
@@ -92,90 +92,46 @@ namespace Modex
 		}
 	}
 
-	// Subtracting -1 from size results in odd font sizes. Good idea?
-	void MergeIconFont(ImGuiIO& io, float size)
-	{
-		ImFontConfig config;
-		config.MergeMode = true;
-		config.GlyphMinAdvanceX = 10.0f;
-		config.GlyphExtraSpacing.x = 5.0f;
-		config.GlyphOffset.y = 3.0f;
-		config.GlyphOffset.x = 1.0f;
-		static const ImWchar icon_ranges[] = { ICON_RPG_MIN, ICON_RPG_MAX, 0 };
-		io.Fonts->AddFontFromFileTTF("Data/Interface/Modex/icons/rpgawesome-webfont.ttf", size - 1.0f, &config, icon_ranges);
-	}
-
-	// TODO: Remove the nano, small, medium, etc indices and replace with a single font size parameter.
-	// This will allow for easier font merging and more universal font usage. Only issue is that the font dpi and scale
-	// might be a problem if changing UI size?
-	void GraphicManager::LoadFontsFromDirectory(std::string a_path, std::map<std::string, Font>& out_struct, Language::GlyphRanges a_range)
-	{
-		if (std::filesystem::exists(a_path) == false) {
-			auto warning = std::string("FATAL ERROR: Font and/or Graphic asset directory not found. This is because Modex cannot locate the path '") + a_path + "'. Check your installation.";
-			stl::report_and_fail(warning);
-			return;
-		}
-
-		auto glyph_ranges = Language::GetLanguageGlyphRange(a_range);
-
-		for (const auto& entry : std::filesystem::directory_iterator(a_path)) {
-			if (entry.path().filename().extension() != ".ttf" && entry.path().filename().extension() != ".otf") {
-				continue;  // Pass invalid file types
-			}
-
-			auto index = entry.path().filename().stem().string();
-
-			ImGuiIO& io = ImGui::GetIO();
-			out_struct[index].normal = io.Fonts->AddFontFromFileTTF(entry.path().string().c_str(), 18.0f, NULL, glyph_ranges);
-			MergeIconFont(io, 18.0f);
-			out_struct[index].large = io.Fonts->AddFontFromFileTTF(entry.path().string().c_str(), 20.0f, NULL, glyph_ranges);
-			MergeIconFont(io, 20.0f);
-			out_struct[index].name = index;
-
-			logger::info("Font Index Names: {}", index);
-		}
-	}
-
 	// Setup Default font with compatible font for user's language.
-	void GraphicManager::SetupLanguageFont(Language::GlyphRanges a_range)
-	{
-		auto glyph_range = Language::GetLanguageGlyphRange(a_range);
-		ImGuiIO& io = ImGui::GetIO();
+	// void GraphicManager::SetupLanguageFont(Language::GlyphRanges a_range)
+	// {
+	// 	auto glyph_range = Language::GetLanguageGlyphRange(a_range);
+	// 	ImGuiIO& io = ImGui::GetIO();
 
-		switch (a_range) {
-		case Language::GlyphRanges::Chinese:
-			font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\simsun.ttc", 18.0f, NULL, glyph_range);
-			MergeIconFont(io, 18.0f);
-			font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\simsun.ttc", 20.0f, NULL, glyph_range);
-			MergeIconFont(io, 20.0f);
-			break;
-		case Language::GlyphRanges::Japanese:
-			font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\msgothic.ttc", 18.0f, NULL, glyph_range);
-			MergeIconFont(io, 18.0f);
-			font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\msgothic.ttc", 20.0f, NULL, glyph_range);
-			MergeIconFont(io, 20.0f);
-			break;
-		case Language::GlyphRanges::Korean:
-			font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\malgun.ttf", 18.0f, NULL, glyph_range);
-			MergeIconFont(io, 18.0f);
-			font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\malgun.ttf", 20.0f, NULL, glyph_range);
-			MergeIconFont(io, 20.0f);
-			break;
-		case Language::GlyphRanges::Russian:
-			font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\arial.ttf", 18.0f, NULL, glyph_range);
-			MergeIconFont(io, 18.0f);
-			font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\arial.ttf", 20.0f, NULL, glyph_range);
-			MergeIconFont(io, 20.0f);
-			break;
-		default:
-			ImFontConfig config;
-			config.SizePixels = 20.0f;
-			font_library["Default"].normal = io.Fonts->AddFontDefault();
-			MergeIconFont(io, 18.0f);
-			font_library["Default"].large = io.Fonts->AddFontDefault(&config);
-			MergeIconFont(io, 20.0f);
-		}
-	}
+	// 	switch (a_range) {
+	// 	case Language::GlyphRanges::Chinese:
+	// 		font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\simsun.ttc", 18.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 18.0f);
+	// 		font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\simsun.ttc", 20.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 20.0f);
+	// 		break;
+	// 	case Language::GlyphRanges::Japanese:
+	// 		font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\msgothic.ttc", 18.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 18.0f);
+	// 		font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\msgothic.ttc", 20.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 20.0f);
+	// 		break;
+	// 	case Language::GlyphRanges::Korean:
+	// 		font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\malgun.ttf", 18.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 18.0f);
+	// 		font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\malgun.ttf", 20.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 20.0f);
+	// 		break;
+	// 	case Language::GlyphRanges::Russian:
+	// 		font_library["Default"].normal = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\arial.ttf", 18.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 18.0f);
+	// 		font_library["Default"].large = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\arial.ttf", 20.0f, NULL, glyph_range);
+	// 		MergeIconFont(io, 20.0f);
+	// 		break;
+	// 	default:
+	// 		ImFontConfig config;
+	// 		config.SizePixels = 20.0f;
+	// 		font_library["Default"].normal = io.Fonts->AddFontDefault();
+	// 		MergeIconFont(io, 18.0f);
+	// 		font_library["Default"].large = io.Fonts->AddFontDefault(&config);
+	// 		MergeIconFont(io, 20.0f);
+	// 	}
+	// }
 
 	void GraphicManager::DrawImage(Image& a_image, ImVec2 a_center)
 	{
@@ -215,16 +171,16 @@ namespace Modex
 
 		// Set the default font to what the user has selected in the settings.
 		// For non-english users, this will replace the ImGui default font.
-		auto config = Settings::GetSingleton()->GetConfig();
-		SetupLanguageFont(config.glyphRange);
+
+		//auto config = Settings::GetSingleton()->GetConfig();
+		//SetupLanguageFont(config.glyphRange);
 
 		// Load any user-installed fonts from fonts directory.
-		GraphicManager::LoadFontsFromDirectory(std::string("Data/Interface/Modex/fonts"), GraphicManager::font_library, config.glyphRange);
+		//GraphicManager::LoadFontsFromDirectory(std::string("Data/Interface/Modex/fonts"), GraphicManager::font_library, config.glyphRange);
 
 		// Detect ImGui Icons mod and load it if it exists.
 		if (std::filesystem::exists("Data/Interface/ImGuiIcons")) {
 			GraphicManager::LoadImagesFromFilepath(std::string("Data/Interface/ImGuiIcons/Icons"), GraphicManager::imgui_library);
-			GraphicManager::LoadFontsFromDirectory(std::string("Data/Interface/ImGuiIcons/Fonts"), GraphicManager::font_library, config.glyphRange);
 			logger::info("Successfully found and loaded ImGui Icon Library.");
 		}
 

--- a/src/Graphic.h
+++ b/src/Graphic.h
@@ -20,51 +20,27 @@ namespace Modex
 			int32_t height = 0;
 		};
 
-		struct Font
-		{
-			std::string name = "Default";
-			ImFont* normal = nullptr;
-			ImFont* large = nullptr;
-
-			bool operator==(const Font& other) const
-			{
-				return name.compare(other.name) == 0;
-			}
-		};
-
-		enum FontSize
-		{
-			Nano,
-			Tiny,
-			Medium,
-			Large
-		};
-
 		static inline std::map<std::string, GraphicManager::Image> image_library;
 		static inline std::map<std::string, GraphicManager::Image> imgui_library;
-		static inline std::map<std::string, Font> font_library;
-		static inline std::map<std::string, Font> icon_library;
 
 		static void DrawImage(Image& a_texture, ImVec2 a_center);
 		static void LoadImagesFromFilepath(std::string a_path, std::map<std::string, Image>& out_struct);
-		static void LoadFontsFromDirectory(std::string a_path, std::map<std::string, Font>& out_struct, Language::GlyphRanges a_range);
-		static void SetupLanguageFont(Language::GlyphRanges a_range);
 
 		static void Init();
 
 		[[nodiscard]] static bool GetD3D11Texture(const char* filename, ID3D11ShaderResourceView** out_srv, int& out_width,
 			int& out_height);
 
-		[[nodiscard]] static Font GetFont(std::string a_font)
-		{
-			auto found = font_library.find(a_font);
-			if (found != font_library.end()) {
-				return found->second;
-			}
+		// [[nodiscard]] static Font GetFont(std::string a_font)
+		// {
+		// 	auto found = font_library.find(a_font);
+		// 	if (found != font_library.end()) {
+		// 		return found->second;
+		// 	}
 
-			logger::warn("Font Reference not found: {}", a_font);
-			return Font();
-		}
+		// 	logger::warn("Font Reference not found: {}", a_font);
+		// 	return Font();
+		// }
 
 		[[nodiscard]] static Image GetImage(std::string a_name)
 		{

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -68,7 +68,7 @@ void hk_PollInputDevices(RE::BSTEventSource<RE::InputEvent*>* a_dispatcher, RE::
 	}
 
 	if (menu->IsEnabled()) {
-		_InputHandler(a_dispatcher, dummy);
+		_InputHandler(a_dispatcher, dummy);  // Block Input Events to Skyrim
 		return;
 	} else {
 		_InputHandler(a_dispatcher, a_events);

--- a/src/Language.cpp
+++ b/src/Language.cpp
@@ -1,0 +1,138 @@
+#include "Language.h"
+#include "Settings.h"
+#include <codecvt>
+
+namespace Modex
+{
+
+	// Convert wide string to UTF-8 string.
+	std::string WideToUTF8(const std::wstring& a_wide)
+	{
+		std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+		return converter.to_bytes(a_wide);
+	}
+
+	void FontManager::BuildFontLibrary()
+	{
+		// Note to self: do not remove this fucking warning.
+		if (std::filesystem::exists(font_path) == false) {
+			stl::report_and_fail("FATAL ERROR: Font and/or Graphic asset directory not found. This is because Modex cannot locate the path 'Data/Interface/Modex/Fonts/'. Check your installation.");
+			return;
+		}
+
+		// Search for fonts relative to Modex directory.
+		for (const auto& entry : std::filesystem::directory_iterator(font_path)) {
+			if (entry.path().filename().extension() != ".ttf" && entry.path().filename().extension() != ".otf") {
+				continue;  // Pass invalid file types
+			}
+
+			FontData data;
+			data.name = WideToUTF8(entry.path().filename().stem().wstring());
+			data.fullPath = WideToUTF8(entry.path().wstring());
+
+			font_library[data.name] = data;
+
+			logger::info("Font Index Names: {}", data.name);
+		}
+
+		// Search for fonts relative to ImGui Icon Library directory.
+		if (std::filesystem::exists(imgui_font_path)) {
+			for (const auto& entry : std::filesystem::directory_iterator(imgui_font_path)) {
+				if (entry.path().filename().extension() != ".ttf" && entry.path().filename().extension() != ".otf") {
+					continue;  // Pass invalid file types
+				}
+
+				FontData data;
+				data.name = WideToUTF8(entry.path().filename().stem().wstring());
+				data.fullPath = WideToUTF8(entry.path().wstring());
+
+				font_library[data.name] = data;
+
+				logger::info("Font Index Names: {}", data.name);
+			}
+		}
+	}
+
+	// Subtracting -1 from size results in odd font sizes. Good idea?
+	void FontManager::MergeIconFont(ImGuiIO& io, float size)
+	{
+		ImFontConfig imFontConfig;
+		imFontConfig.MergeMode = true;
+		imFontConfig.GlyphMinAdvanceX = 10.0f;
+		imFontConfig.GlyphExtraSpacing.x = 5.0f;
+		imFontConfig.GlyphOffset.y = 3.0f;
+		imFontConfig.GlyphOffset.x = 1.0f;
+
+		static const ImWchar icon_ranges[] = { ICON_RPG_MIN, ICON_RPG_MAX, 0 };
+		io.Fonts->AddFontFromFileTTF("Data/Interface/Modex/icons/rpgawesome-webfont.ttf", size - 1.0f, &imFontConfig, icon_ranges);
+	}
+
+	void FontManager::AddDefaultFont()
+	{
+		auto& style = Settings::GetSingleton()->GetStyle();
+		auto& config = Settings::GetSingleton()->GetConfig();
+		auto& io = ImGui::GetIO();
+
+		ImFontConfig imFontConfig;
+		imFontConfig.SizePixels = (float)config.globalFontSize;
+
+		auto glyphRange = Language::GetUserGlyphRange(config.glyphRange);
+
+		switch (config.glyphRange) {
+		case Language::GlyphRanges::ChineseFull:
+		case Language::GlyphRanges::ChineseSimplified:
+			io.Fonts->AddFontFromFileTTF(chinese_font, imFontConfig.SizePixels, NULL, glyphRange);
+			break;
+		case Language::GlyphRanges::Japanese:
+			io.Fonts->AddFontFromFileTTF(japanese_font, imFontConfig.SizePixels, NULL, glyphRange);
+			break;
+		case Language::GlyphRanges::Korean:
+			io.Fonts->AddFontFromFileTTF(korean_font, imFontConfig.SizePixels, NULL, glyphRange);
+			break;
+		default:  // English / Latin; Greek; Cryillic; Thai; Vietnamese (?)
+			io.Fonts->AddFontDefault(&imFontConfig);
+			break;
+		}
+
+		if (!style.noIconText) {
+			MergeIconFont(io, imFontConfig.SizePixels);
+		}
+	}
+
+	// Do not call this function directly. See Menu::RebuildFontAtlas().
+	// Builds a single font from file with appropriate glyph range.
+	void FontManager::LoadCustomFont(FontData& a_font, float a_size)
+	{
+		auto& io = ImGui::GetIO();
+		auto& config = Settings::GetSingleton()->GetConfig();
+		auto& style = Settings::GetSingleton()->GetStyle();
+
+		const auto& glyphRange = Language::GetUserGlyphRange(config.glyphRange);
+
+		io.Fonts->AddFontFromFileTTF(a_font.fullPath.c_str(), a_size, NULL, glyphRange);
+
+		// TODO: Refresh font when this changes.
+		if (!style.noIconText) {
+			MergeIconFont(io, a_size);
+		}
+	}
+
+	// Runs after Settings are loaded.
+	void FontManager::SetStartupFont()
+	{
+		logger::info("[Font Manager] Setting startup font.");
+		auto& config = Settings::GetSingleton()->GetConfig();
+		auto& fontData = GetFontData(config.globalFont);
+
+		if (std::filesystem::exists(fontData.fullPath) == true) {
+			logger::info("[Font Manager] Loading custom font: {}", fontData.name);
+			LoadCustomFont(fontData, (float)config.globalFontSize);
+		} else {
+			logger::info("[Font Manager] No Custom font specified. Loading default font.");
+			AddDefaultFont();
+		}
+
+		// io.FontDefault = io.Fonts->Fonts[0];
+	}
+
+}

--- a/src/Language.h
+++ b/src/Language.h
@@ -4,7 +4,6 @@
 
 namespace Modex
 {
-
 	class Translate
 	{
 	public:
@@ -109,11 +108,15 @@ namespace Modex
 
 		enum GlyphRanges
 		{
-			Default,
-			Chinese,
+			English,
+			Greek,
+			Korean,
 			Japanese,
-			Russian,
-			Korean
+			ChineseFull,
+			ChineseSimplified,
+			Cryillic,
+			Thai,
+			Vietnamese
 		};
 
 		static inline std::set<std::string> languages;
@@ -134,62 +137,158 @@ namespace Modex
 					std::string path = entry.path().filename().string();
 					languages.insert(path.substr(0, path.find_last_of('.')));
 
-					logger::info("Added language to master list: {}", path);
+					logger::info("[Language] Added language to master list: {}", path);
 				}
 			}
 		}
 
-		static const ImWchar* GetLanguageGlyphRange(GlyphRanges a_range)
+		static const ImWchar* GetUserGlyphRange(GlyphRanges a_range)
 		{
+			auto& io = ImGui::GetIO();
+
 			switch (a_range) {
-			case GlyphRanges::Chinese:
-				return ImGui::GetIO().Fonts->GetGlyphRangesChineseFull();
-			case GlyphRanges::Japanese:
-				return ImGui::GetIO().Fonts->GetGlyphRangesJapanese();
-			case GlyphRanges::Russian:
-				return ImGui::GetIO().Fonts->GetGlyphRangesCyrillic();
+			case GlyphRanges::English:
+				return io.Fonts->GetGlyphRangesDefault();  // Basic Latin, Extended Latin
+			case GlyphRanges::Greek:
+				return io.Fonts->GetGlyphRangesGreek();  // Default + Greek and Coptic
 			case GlyphRanges::Korean:
-				return ImGui::GetIO().Fonts->GetGlyphRangesKorean();
+				return io.Fonts->GetGlyphRangesKorean();  // Default + Korean characters
+			case GlyphRanges::Japanese:
+				return io.Fonts->GetGlyphRangesJapanese();  // Default + Hiragana, Katakana, Half-Width, Selection of 2999 Ideographs
+			case GlyphRanges::ChineseFull:
+				return io.Fonts->GetGlyphRangesChineseFull();  // Default + Half-Width + Japanese Hiragana/Katakana + full set of about 21000 CJK Unified Ideographs
+			case GlyphRanges::ChineseSimplified:
+				return io.Fonts->GetGlyphRangesChineseSimplifiedCommon();  // Default + Half-Width + Japanese Hiragana/Katakana + set of 2500 CJK Unified Ideographs for common simplified Chinese
+			case GlyphRanges::Cryillic:
+				return io.Fonts->GetGlyphRangesCyrillic();  // Default + about 400 Cyrillic characters
+			case GlyphRanges::Thai:
+				return io.Fonts->GetGlyphRangesThai();  // Default + Thai characters
+			case GlyphRanges::Vietnamese:
+				return io.Fonts->GetGlyphRangesVietnamese();  // Default + Vietnamese characters
 			default:
-				return ImGui::GetIO().Fonts->GetGlyphRangesDefault();
-			}
+				return io.Fonts->GetGlyphRangesDefault();  // Basic Latin, Extended Latin
+			};
 		}
 
 		[[nodiscard]] static GlyphRanges GetGlyphRange(std::string a_language)
 		{
-			if (a_language == "Chinese") {
-				return GlyphRanges::Chinese;
-			} else if (a_language == "Japanese") {
-				return GlyphRanges::Japanese;
-			} else if (a_language == "Russian") {
-				return GlyphRanges::Russian;
-			} else if (a_language == "Korean") {
+			if (a_language.compare("English") == 0) {
+				return GlyphRanges::English;
+			} else if (a_language.compare("Greek") == 0) {
+				return GlyphRanges::Greek;
+			} else if (a_language.compare("Korean") == 0) {
 				return GlyphRanges::Korean;
+			} else if (a_language.compare("Japanese") == 0) {
+				return GlyphRanges::Japanese;
+			} else if (a_language.compare("ChineseFull") == 0) {
+				return GlyphRanges::ChineseFull;
+			} else if (a_language.compare("ChineseSimplified") == 0) {
+				return GlyphRanges::ChineseSimplified;
+			} else if (a_language.compare("Cryillic") == 0) {
+				return GlyphRanges::Cryillic;
+			} else if (a_language.compare("Thai") == 0) {
+				return GlyphRanges::Thai;
+			} else if (a_language.compare("Vietnamese") == 0) {
+				return GlyphRanges::Vietnamese;
 			} else {
-				return GlyphRanges::Default;
+				return GlyphRanges::English;
 			}
 		}
 
 		[[nodiscard]] static std::string GetGlyphName(GlyphRanges a_range)
 		{
 			switch (a_range) {
-			case GlyphRanges::Chinese:
-				return "Chinese";
-			case GlyphRanges::Japanese:
-				return "Japanese";
-			case GlyphRanges::Russian:
-				return "Russian";
+			case GlyphRanges::English:
+				return "English";
+			case GlyphRanges::Greek:
+				return "Greek";
 			case GlyphRanges::Korean:
 				return "Korean";
+			case GlyphRanges::Japanese:
+				return "Japanese";
+			case GlyphRanges::ChineseFull:
+				return "ChineseFull";
+			case GlyphRanges::ChineseSimplified:
+				return "ChineseSimplified";
+			case GlyphRanges::Cryillic:
+				return "Cryillic";
+			case GlyphRanges::Thai:
+				return "Thai";
+			case GlyphRanges::Vietnamese:
+				return "Vietnamese";
 			default:
-				return "Default";
-			}
+				return "English";
+			};
 		}
 
 		// Not going to bother making this fancy.
 		[[nodiscard]] static std::set<std::string> GetListOfGlyphNames()
 		{
-			return { "Default", "Chinese", "Japanese", "Russian", "Korean" };
+			return { "English", "Greek", "Korean", "Japanese", "ChineseFull", "ChineseSimplified", "Cryillic", "Thai", "Vietnamese" };
 		}
+	};
+
+	class FontManager
+	{
+	public:
+		enum class FontSize
+		{
+			Small,
+			Medium,
+			Large,
+		};
+
+		struct FontData
+		{
+			std::string name;
+			std::string fullPath;
+		};
+
+		static inline FontManager* GetSingleton()
+		{
+			static FontManager singleton;
+			return &singleton;
+		}
+
+		void LoadCustomFont(FontData& a_font, float a_size);
+		void MergeIconFont(ImGuiIO& io, float size);
+		void SetStartupFont();
+		void BuildFontLibrary();
+
+		// Returns std::map<std::string, FontData>
+		[[nodiscard]] static inline FontData& GetFontData(const std::string& a_name)
+		{
+			return font_library[a_name];
+		}
+
+		// Returns a sorted list of registered fonts.
+		[[nodiscard]] static inline std::vector<std::string> GetFontLibrary()
+		{
+			std::vector<std::string> fonts;
+			for (const auto& [key, value] : font_library) {
+				fonts.push_back(key);
+			}
+
+			std::sort(fonts.begin(), fonts.end());
+			return fonts;
+		}
+
+		// members
+		static inline std::map<std::string, FontData> font_library;
+
+	private:
+		inline static const wchar_t* font_path = L"Data/Interface/Modex/Fonts/";
+		inline static const wchar_t* imgui_font_path = L"Data/Interface/ImGuiIcons/Fonts";
+
+		inline static const char* chinese_font = "c:\\Windows\\Fonts\\simsun.ttc";
+		inline static const char* japanese_font = "c:\\Windows\\Fonts\\msgothic.ttc";
+		inline static const char* korean_font = "c:\\Windows\\Fonts\\malgun.ttf";
+
+		void AddDefaultFont();
+
+		FontManager() = default;
+		~FontManager() = default;
+		FontManager(const FontManager&) = delete;
+		FontManager& operator=(const FontManager&) = delete;
 	};
 }

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1,5 +1,6 @@
 #include "Menu.h"
 #include "Console.h"
+#include "Graphic.h"
 #include "Utils/Keycode.h"
 #include "Windows/Frame.h"
 #include "Windows/UserSettings/UserSettings.h"
@@ -31,7 +32,13 @@ namespace Modex
 		Console::ProcessMainThreadTasks();
 
 		if (!IsEnabled()) {
-			return;  // TODO: Should this be called one level up?
+			return;
+		}
+
+		if (_rebuildFonts) {
+			RebuildFontAtlas();
+
+			return;
 		}
 
 		ImGui_ImplWin32_NewFrame();
@@ -45,9 +52,9 @@ namespace Modex
 			ImGui::GetIO().MouseDrawCursor = false;
 		}
 
-		ImGui::PushFont(Settings::GetSingleton()->GetStyle().font.normal);
+		//ImGui::PushFont(Settings::GetSingleton()->GetStyle().font.normal);
 		Frame::Draw(is_settings_popped);
-		ImGui::PopFont();
+		//ImGui::PopFont();
 
 		//ImGui::ShowDemoWindow();
 
@@ -55,6 +62,24 @@ namespace Modex
 
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+	}
+
+	void Menu::RefreshFont()
+	{
+		_rebuildFonts = true;
+	}
+
+	void Menu::RebuildFontAtlas()
+	{
+		ImGuiIO& io = ImGui::GetIO();
+		io.Fonts->Clear();
+
+		FontManager::GetSingleton()->SetStartupFont();
+
+		io.Fonts->Build();
+		ImGui_ImplDX11_InvalidateDeviceObjects();
+
+		_rebuildFonts = false;
 	}
 
 	void Menu::Init(IDXGISwapChain* a_swapchain, ID3D11Device* a_device, ID3D11DeviceContext* a_context)
@@ -107,7 +132,7 @@ namespace Modex
 		auto& style = ImGui::GetStyle();
 		auto& colors = style.Colors;
 
-		ImGui::GetIO().FontGlobalScale = user.globalFontSize;
+		// ImGui::GetIO().FontGlobalScale = user.globalFontSize;
 
 		colors[ImGuiCol_Text] = user.text;
 		colors[ImGuiCol_TextDisabled] = user.textDisabled;
@@ -179,7 +204,7 @@ namespace Modex
 		_isCtrlDown = false;
 		_isAltDown = false;
 		_isOpenModDown = false;
-		}
+	}
 
 	void Menu::ProcessInputEvent(RE::InputEvent** a_event)
 	{

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -14,6 +14,7 @@ namespace Modex
 		void ProcessInputEvent(RE::InputEvent** a_event);
 		void RefreshStyle();
 		void OnFocusKill();
+		void RefreshFont();
 
 		bool IsEnabled() { return enable; }
 		void SetEnabled(bool value) { enable = value; }
@@ -47,6 +48,7 @@ namespace Modex
 
 		static inline bool is_settings_popped = false;
 		static inline std::atomic<bool> initialized = false;
+		static inline bool _rebuildFonts = false;
 		static inline bool _prevFreeze = false;
 
 		static inline bool _isShiftDown = false;
@@ -56,6 +58,8 @@ namespace Modex
 
 	private:
 		bool enable = false;
+
+		void RebuildFontAtlas();
 	};
 
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -19,7 +19,7 @@ namespace Modex
 
 		void GetIni(const wchar_t* a_path, const std::function<void(CSimpleIniA&)> a_func);
 		void LoadSettings(const wchar_t* a_path);
-		void LoadFont();
+		void LoadUserFontSetting();
 		void SaveSettings();
 		void LoadMasterIni(CSimpleIniA& a_ini);
 		void LoadThemeFromIni(CSimpleIniA& a_ini);
@@ -73,15 +73,21 @@ namespace Modex
 
 		struct Config
 		{
+			// General
 			std::string theme = "Default";
-			int showMenuKey;
-			int showMenuModifier;
-			std::string language = "English";
-			Language::GlyphRanges glyphRange = Language::GlyphRanges::Default;
-			int modListSort;  // 0 = Alphabetical, 1 = Installation (WIN ONLY)
-			int uiScale;      // 80, 90, 100, 110, 120 (Should be a slider..)
+			int showMenuKey = 211;
+			int showMenuModifier = 0;
+			int modListSort = 0;  // 0 = Alphabetical, 1 = Installation (WIN ONLY)
+			int uiScale = 100;    // 80, 90, 100, 110, 120 (Should be a slider..)
 			bool pauseGame = false;
 
+			// Font Stuff
+			std::string language = "English";
+			Language::GlyphRanges glyphRange = Language::GlyphRanges::English;
+			std::string globalFont = "Default";
+			int globalFontSize = 16;
+
+			// Modules
 			int defaultShow = 1;  // 0 = Home, 1 = AddItem, 2 = Object, 3 = NPC, 4 = Teleport, 5 = Settings
 			bool showHomeMenu = false;
 			bool showAddItemMenu = true;
@@ -151,13 +157,9 @@ namespace Modex
 			float scrollbarSize = 14;
 			float grabMinSize = 10;
 			float grabRounding = 3;
-			float globalFontSize = 1.0;
 
 			bool showTableRowBG = true;
 			bool noIconText = false;
-
-			GraphicManager::Font font;
-			GraphicManager::Font buttonFont;
 
 			GraphicManager::Image splashImage;
 		};
@@ -176,7 +178,7 @@ namespace Modex
 
 		// https://github.com/powerof3/PhotoMode | License: MIT
 		template <class T>
-		static std::string ToString(const T& a_style, bool a_hex)
+		static std::string ToString(const T& a_style, bool a_hex = false)
 		{
 			if constexpr (std::is_same_v<ImVec4, T>) {
 				if (a_hex) {
@@ -187,7 +189,7 @@ namespace Modex
 				return std::format("{}{},{}{}", "{", a_style.x, a_style.y, "}");
 			} else if constexpr (std::is_same_v<std::string, T>) {
 				return a_style;
-			} else if constexpr (std::is_same_v<GraphicManager::Font, T>) {
+			} else if constexpr (std::is_same_v<FontManager::FontData, T>) {
 				return a_style.name;
 			} else if constexpr (std::is_same_v<GraphicManager::Image, T>) {
 				return GraphicManager::GetImageName(a_style);
@@ -252,11 +254,6 @@ namespace Modex
 			logger::critical("Failed to parse ImVec2 from .ini file! Ensure you're using the correct format!");
 			logger::critical("ImVec2 input: {}", a_str);
 			return { ImVec2(), false };
-		}
-
-		static std::map<std::string, GraphicManager::Font> GetListOfFonts()
-		{
-			return GraphicManager::font_library;
 		}
 
 		static std::map<std::string, GraphicManager::Image> GetListOfImages()

--- a/src/Utils/Util.h
+++ b/src/Utils/Util.h
@@ -13,7 +13,7 @@ namespace ImGui
 
 	inline static void ShowLanguagePopup()
 	{
-		auto& style = Modex::Settings::GetSingleton()->GetStyle();
+		// auto& style = Modex::Settings::GetSingleton()->GetStyle();
 
 		auto width = ImGui::GetMainViewport()->Size.x * 0.25f;
 		auto height = ImGui::GetMainViewport()->Size.y * 0.20f;
@@ -29,11 +29,11 @@ namespace ImGui
 		ImGui::SetNextWindowPos(ImVec2(pos_x, pos_y));
 		if (ImGui::BeginPopupModal("Non-latin Alphabetical Language", nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar)) {
 			ImGui::SetCursorPosX(ImGui::GetCenterTextPosX("Non-latin Alphabetical Language"));
-			ImGui::PushFont(style.font.normal);
+			// ImGui::PushFont(style.font.normal);
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.5f, 0.5f, 1.0f));
 			ImGui::Text("Non-latin Alphabetical Language");
 			ImGui::PopStyleColor(1);
-			ImGui::PopFont();
+			// ImGui::PopFont();
 
 			ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
 
@@ -63,7 +63,7 @@ namespace ImGui
 	// Call ImGui::ShowWarningPopup(<popup_name>, <callback>) outside of conditional logic.
 	inline static void ShowWarningPopup(const char* warning, std::function<void()> callback)
 	{
-		auto& style = Modex::Settings::GetSingleton()->GetStyle();
+		// auto& style = Modex::Settings::GetSingleton()->GetStyle();
 
 		auto width = ImGui::GetMainViewport()->Size.x * 0.25f;
 		auto height = ImGui::GetMainViewport()->Size.y * 0.20f;
@@ -79,11 +79,11 @@ namespace ImGui
 		ImGui::SetNextWindowPos(ImVec2(pos_x, pos_y));
 		if (ImGui::BeginPopupModal(warning, nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoScrollbar)) {
 			ImGui::SetCursorPosX(ImGui::GetCenterTextPosX(warning));
-			ImGui::PushFont(style.font.normal);
+			// ImGui::PushFont(style.font.normal);
 			ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.5f, 0.5f, 1.0f));
 			ImGui::Text(warning);
 			ImGui::PopStyleColor(1);
-			ImGui::PopFont();
+			// ImGui::PopFont();
 
 			ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
 
@@ -116,9 +116,11 @@ namespace ImGui
 
 	inline static bool m_Button(const char* label, Modex::Settings::Style& style, const ImVec2& size = ImVec2(0, 0))
 	{
-		ImGui::PushFont(style.buttonFont.normal);
+		(void)style;
+
+		// ImGui::PushFont(style.buttonFont.normal);
 		auto result = ImGui::Button(label, size);
-		ImGui::PopFont();
+		// ImGui::PopFont();
 		return result;
 	}
 
@@ -132,9 +134,9 @@ namespace ImGui
 		auto innerPadding = style.widgetPadding.y;
 		auto newSize = ImVec2(size.x, size.y + innerPadding);
 
-		ImGui::PushFont(style.buttonFont.normal);
+		// ImGui::PushFont(style.buttonFont.normal);
 		auto result = ImGui::Selectable(label, &selected, flag, newSize);
-		ImGui::PopFont();
+		// ImGui::PopFont();
 		return result;
 	}
 

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -20,10 +20,12 @@ namespace
 			Modex::PersistentData::LoadBlacklist();
 			logger::info("Loaded Persistent Data");
 			Modex::Language::GetSingleton()->BuildLanguageList();
-			logger::info("Finished Building Language List");
+			Modex::FontManager::GetSingleton()->BuildFontLibrary();
+			logger::info("Finished Building Language & Font List");
 			Modex::Settings::GetSingleton()->LoadSettings(Modex::Settings::ini_mem_path);
+			Modex::Settings::GetSingleton()->LoadUserFontSetting();
+			Modex::FontManager::GetSingleton()->SetStartupFont();
 			Modex::GraphicManager::Init();
-			Modex::Settings::GetSingleton()->LoadFont();
 			Modex::Data::GetSingleton()->Run();
 			Modex::Frame::Install();
 			break;

--- a/src/windows/Frame.cpp
+++ b/src/windows/Frame.cpp
@@ -73,7 +73,7 @@ namespace Modex
 		ImGui::PushStyleColor(ImGuiCol_HeaderActive, style.buttonActive);
 		ImGui::PushStyleColor(ImGuiCol_HeaderHovered, style.buttonHovered);
 		ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 0.5f));
-		ImGui::PushFont(style.buttonFont.normal);
+		// ImGui::PushFont(style.buttonFont.normal);
 		if (ImGui::Begin("##AddItemMenuSideBar", NULL, sidebar_flag + noFocus)) {
 			auto iWidth = ImGui::GetContentRegionAvail().x;
 			auto iHeight = ImGui::GetWindowSize().y / 12;
@@ -133,7 +133,7 @@ namespace Modex
 
 			ImGui::End();
 		}
-		ImGui::PopFont();
+		// ImGui::PopFont();
 		ImGui::PopStyleColor(3);
 		ImGui::PopStyleVar(1);
 


### PR DESCRIPTION
Fixes #31

Entire Font refactor and restructure. Separated it into its own class with its own methods and members.

- Moved Font drop-down to General Config from Style
- Moved Font Size to General Config from Style
- Fonts can now be updated and changed at runtime without reset
- More safe font name lookup for localization