### PR TITLE
[General] Delete Key safety

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -8,7 +8,9 @@ static inline REL::Relocation<decltype(hk_PollInputDevices)> _InputHandler;  // 
 void hk_PollInputDevices(RE::BSTEventSource<RE::InputEvent*>* a_dispatcher, RE::InputEvent** a_events)
 {
 	if (a_events) {
-		Modex::InputManager::GetSingleton()->ProcessInputEvent(a_events);
+		if (Modex::InputManager::GetSingleton()->ShouldProcessEvent(a_events)) {
+			Modex::InputManager::GetSingleton()->ProcessInputEvent(a_events);
+		}
 	}
 
 	if (Modex::InputManager::GetSingleton()->captureInput) {

--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -36,6 +36,56 @@ namespace Modex
 		captureInput = false;
 	}
 
+	// TODO: Is this the best way (?)
+	bool InputManager::ShouldProcessEvent(RE::InputEvent** a_event)
+	{
+		(void)a_event;
+
+		// Don't need this fix if we have a modifier, since it wouldn't fire anyway.
+		if (this->showMenuModifier != 0) {
+			return true;
+		}
+
+		// If the hotkey assigned to Modex doesn't overlap text-input behavioral keys, then we can process the event.
+		if (this->showMenuKey != 0x0E &&  // Backspace
+			this->showMenuKey != 0x0F &&  // Tab
+			this->showMenuKey != 0x3A &&  // Caps-Lock
+			this->showMenuKey != 0x45 &&  // Num-Lock
+			this->showMenuKey != 0x46 &&  // Scroll-Lock
+			this->showMenuKey != 0xB7 &&  // Prnt-Scrn
+			this->showMenuKey != 0xC5 &&  // Pause
+			this->showMenuKey != 0xC7 &&  // Home
+			this->showMenuKey != 0xC8 &&  // Up
+			this->showMenuKey != 0xC9 &&  // Page-Up
+			this->showMenuKey != 0xCB &&  // Left
+			this->showMenuKey != 0xCD &&  // Right
+			this->showMenuKey != 0xCF &&  // End
+			this->showMenuKey != 0xD0 &&  // Down
+			this->showMenuKey != 0xD1 &&  // Page-Down
+			this->showMenuKey != 0xD2 &&  // Insert
+			this->showMenuKey != 0xD3) {  // Delete
+			return true;
+		}
+
+		const auto UIManager = RE::UI::GetSingleton();
+
+		if (UIManager->IsMenuOpen("Console") ||         // Text Input
+			UIManager->IsMenuOpen("Dialogue Menu") ||   // Dialogue
+			UIManager->IsMenuOpen("Crafting Menu") ||   // Text Input
+			UIManager->IsMenuOpen("Training Menu") ||   // Just Incase
+			UIManager->IsMenuOpen("MagicMenu") ||       // Text Input
+			UIManager->IsMenuOpen("Quantity Menu") ||   // Text Input
+			UIManager->IsMenuOpen("RaceSex Menu") ||    // Text Input
+			UIManager->IsMenuOpen("BarterMenu") ||      // Text Input
+			UIManager->IsMenuOpen("InventoryMenu") ||   // Text Input
+			UIManager->IsMenuOpen("ContainerMenu") ||   // Text Input
+			UIManager->IsMenuOpen("MessageBoxMenu")) {  // Text Input
+			return false;
+		}
+
+		return true;
+	}
+
 	void InputManager::ProcessInputEvent(RE::InputEvent** a_event)
 	{
 		// Since inputs can be listened to outside of the menu. Issue #48

--- a/src/include/I/InputManager.h
+++ b/src/include/I/InputManager.h
@@ -38,6 +38,7 @@ namespace Modex
         void        OnFocusKill();
         void        UpdateSettings();
         void        ProcessInputEvent(RE::InputEvent** a_event);
+        bool        ShouldProcessEvent(RE::InputEvent** a_event);
 
         // members
         uint32_t       showMenuKey;


### PR DESCRIPTION
Fixes #52

The following keys can now be set (without a modifier), and will no longer open Modex in menus that may interfere.

- Backspace
- Tab
- Caps-Lock
- Num-Lock
- Scroll-Lock
- Prnt-Scrn
- Pause
- Home
- Arrow Up
- Arrow Down
- Arrow Left
- Arrow Right
- Pg Up
- Pg Down
- End
- Insert
- Delete (most importantly).

Menus that are ignored:

- "Console"
- "Dialogue Menu"
- "Crafting Menu"
- "Training Menu"
- "Magic Menu"
- "Inventory Menu"
- "Quantity Menu"
- "Race Menu"
- "Barter Menu"
- "Container Menu"
- "MessageBox Menu"

I elected to implement this as a two-part solution because some users may want the menu to open over existing Skyrim menus. In which case, they simply can use an alternative hotkey. I found that IED (default backspace) opens in menus anyways. So not sure how significant this change really is.
