### PR TITLE
Try integrate SimpleIME

### DIFF
--- a/src/InputManager.cpp
+++ b/src/InputManager.cpp
@@ -1,5 +1,6 @@
 #include "include/I/InputManager.h"
 #include "include/U/UIManager.h"
+#include "include/S/SimpleImeIntegration.h"
 
 namespace Modex
 {
@@ -74,7 +75,11 @@ namespace Modex
 			switch (event->GetEventType()) {
 			case RE::INPUT_EVENT_TYPE::kChar:
 				if (Menu::IsEnabled()) {
-					io.AddInputCharacter(static_cast<const RE::CharEvent*>(event)->keyCode);
+					// don't add input character when SimpleIME enabled.
+					if (!SimpleIME::SimpleImeIntegration::GetSingleton().IsEnabled())
+					{
+						io.AddInputCharacter(static_cast<const RE::CharEvent*>(event)->keyCode);
+					}
 
 					if (!modifierDown) {
 						io.ClearInputKeys();

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -3,6 +3,7 @@
 #include "include/F/Frame.h"
 #include "include/G/Graphic.h"
 #include "include/I/InputManager.h"
+#include "include/S/SimpleImeIntegration.h"
 #include "include/U/UIManager.h"
 #include "include/U/UserSettings.h"
 
@@ -101,6 +102,7 @@ namespace Modex
 			io.ClearInputKeys();
 		}
 
+		SimpleIME::SimpleImeIntegration::GetSingleton().EnableIme(false);
 		isEnabled = false;
 	}
 
@@ -138,6 +140,8 @@ namespace Modex
 		ImGui::EndFrame();
 		ImGui::Render();
 		ImGui_ImplDX11_RenderDrawData(ImGui::GetDrawData());
+
+		SimpleIME::SimpleImeIntegration::GetSingleton().RenderIme();
 	}
 
 	void Menu::RefreshFont()

--- a/src/SimpleImeIntegration.cpp
+++ b/src/SimpleImeIntegration.cpp
@@ -1,0 +1,92 @@
+#include "include/S/SimpleImeIntegration.h"
+#include "imgui.h"
+
+namespace SimpleIME
+{
+	auto SimpleImeIntegration::HandleMessage(SKSE::MessagingInterface::Message* a_msg) -> void
+	{
+		auto& instance = GetSingleton();
+		switch (a_msg->type) {
+		case IME_INTEGRATION_INIT:
+			instance.OnMessageImeIntegrationInit(a_msg);
+			break;
+		case IME_COMPOSITION_RESULT:
+			instance.OnMessageImeCompositionResult(a_msg);
+			break;
+		default:
+			break;
+		}
+	}
+
+	auto SimpleImeIntegration::EnableIme(bool enable) -> bool
+	{
+		if (!isIntegrated || integrationData == nullptr) {
+			isEnabled.store(false);
+			return false;
+		}
+		if (integrationData->EnableIme(enable)) {
+			isEnabled.store(enable);
+			return true;
+		}
+		return false;
+	}
+
+	auto SimpleImeIntegration::RenderIme() -> void
+	{
+		if (!isIntegrated || integrationData == nullptr || !isEnabled) {
+			return;
+		}
+
+		integrationData->RenderIme();
+	}
+
+	auto SimpleImeIntegration::UpdateImeWindowPosition(float posX, float posY) -> void
+	{
+		if (!isIntegrated || integrationData == nullptr || !isEnabled) {
+			return;
+		}
+
+		integrationData->UpdateImeWindowPosition(posX, posY);
+	}
+
+	auto SimpleImeIntegration::UpdateImeWindowPosition() -> void
+	{
+		auto min = ImGui::GetItemRectMin();
+		auto max = ImGui::GetItemRectMax();
+		UpdateImeWindowPosition(min.x, max.y);
+	}
+
+	auto SimpleImeIntegration::OnMessageImeIntegrationInit(Message* a_msg) -> void
+	{
+		logger::debug("SimpleIme: Received message IME_INTEGRATION_INIT");
+		if (isIntegrated.load()) {
+			logger::warn("SimpleIme: already integrated, message will be ignore");
+		}
+
+		if (a_msg->data != nullptr && a_msg->dataLen == sizeof(IntegrationData*)) {
+			integrationData = reinterpret_cast<IntegrationData*>(a_msg->data);
+			isIntegrated.store(true);
+			logger::debug("SimpleIme: Integration successful!");
+		}
+	}
+
+	// wchar_t ptr, dataLen is bytes length
+	auto SimpleImeIntegration::OnMessageImeCompositionResult(Message* a_msg) -> void
+	{
+		if (!isIntegrated) {
+			return;
+		}
+
+		if (a_msg->data != nullptr) {
+			logger::debug("SimpleIme: Received result string!");
+
+			auto* wcharPtr = reinterpret_cast<wchar_t*>(a_msg->data);
+			std::wstring resultString(wcharPtr, a_msg->dataLen / sizeof(wchar_t));
+
+			auto& io = ImGui::GetIO();
+			for (uint32_t const code : resultString) {
+				io.AddInputCharacter(code);
+			}
+		}
+	}
+}

--- a/src/SimpleImeIntegration.cpp
+++ b/src/SimpleImeIntegration.cpp
@@ -61,6 +61,7 @@ namespace SimpleIME
 		logger::debug("SimpleIme: Received message IME_INTEGRATION_INIT");
 		if (isIntegrated.load()) {
 			logger::warn("SimpleIme: already integrated, message will be ignore");
+			return;
 		}
 
 		if (a_msg->data != nullptr && a_msg->dataLen == sizeof(IntegrationData*)) {

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -8,6 +8,7 @@
 #include "include/L/Language.h"
 #include "include/P/Persistent.h"
 #include "include/S/Settings.h"
+#include "include/S/SimpleImeIntegration.h"
 #include <spdlog/sinks/basic_file_sink.h>
 
 namespace
@@ -82,6 +83,9 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	// Install SKSE hooks.
 	auto messaging = SKSE::GetMessagingInterface();
 	if (!messaging->RegisterListener("SKSE", MessageHandler)) {
+		return false;
+	}
+	if (!messaging->RegisterListener("SimpleIME", SimpleIME::SimpleImeIntegration::HandleMessage)) {
 		return false;
 	}
 

--- a/src/include/S/SimpleImeIntegration.h
+++ b/src/include/S/SimpleImeIntegration.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#pragma once
+
+#ifdef SIMPLE_EXPORTS
+#	define SIMPLE_API __declspec(dllexport)
+#else
+#	define SIMPLE_API __declspec(dllimport)
+#endif
+
+namespace SimpleIME
+{
+	enum class SkseImeMessage
+	{
+		IME_INTEGRATION_INIT = 0x100,
+		IME_COMPOSITION_RESULT,
+	};
+
+	struct SIMPLE_API IntegrationData
+	{
+		// Other mod must call this to render IME window
+		void (*RenderIme)() = nullptr;
+		// enable IME for other mod
+		bool (*EnableIme)(bool enable) = nullptr;
+		// update IME window position (the candidate and composition window)
+		void (*UpdateImeWindowPosition)(float posX, float posY) = nullptr;
+	};
+
+	static_assert(sizeof(IntegrationData) == 24);
+
+	class SimpleImeIntegration
+	{
+		using Message = SKSE::MessagingInterface::Message;
+
+	public:
+		enum ImeMessage : std::uint32_t
+		{
+			IME_INTEGRATION_INIT = 0x100,
+			IME_COMPOSITION_RESULT,
+		};
+
+		static auto HandleMessage(Message* a_msg) -> void;
+
+		auto EnableIme(bool enable) -> bool;
+		auto RenderIme() -> void;
+		auto UpdateImeWindowPosition(float posX, float posY) -> void;
+		// Update IME window position by last ImGui item position
+		auto UpdateImeWindowPosition() -> void;
+
+		auto IsEnabled() -> bool
+		{
+			return isEnabled.load();
+		}
+
+		static auto GetSingleton() -> SimpleImeIntegration&
+		{
+			static SimpleImeIntegration g_instance;
+			return g_instance;
+		}
+
+	private:
+		std::atomic_bool isIntegrated = false;
+		std::atomic_bool isEnabled = false;
+		IntegrationData* integrationData = nullptr;
+
+		auto OnMessageImeIntegrationInit(Message* a_msg) -> void;
+		auto OnMessageImeCompositionResult(Message* a_msg) -> void;
+	};
+}

--- a/src/windows/Teleport/Search.cpp
+++ b/src/windows/Teleport/Search.cpp
@@ -1,4 +1,5 @@
 #include "include/P/Persistent.h"
+#include "include/S/SimpleImeIntegration.h"
 #include "include/T/Teleport.h"
 
 namespace Modex
@@ -87,6 +88,13 @@ namespace Modex
 				IM_ARRAYSIZE(inputBuffer),
 				ImGuiInputTextFlags_EscapeClearsAll)) {
 			Refresh();
+		}
+		auto& imeIntegration = SimpleIME::SimpleImeIntegration::GetSingleton();
+		if (ImGui::IsItemActivated()) {
+			imeIntegration.EnableIme(true);
+			imeIntegration.UpdateImeWindowPosition();
+		} else if (ImGui::IsItemDeactivated()) {
+			imeIntegration.EnableIme(false);
 		}
 
 		ImGui::SameLine();


### PR DESCRIPTION
My mod [SimpleIME](https://www.nexusmods.com/skyrimspecialedition/mods/140136?tab=description) has undergone multiple updates and is now relatively stable. This reminded me of Modex, so I implemented some basic processing using SKSE's MessageInterface and integrated SimpleIME.

Currently, I've added IME support to Modex's teleport search widget, and it appears to function perfectly.

```c++
if (ImGui::InputTextWithHint("##TeleportWindow::InputField", _T("GENERAL_CLICK_TO_TYPE"), inputBuffer,
		IM_ARRAYSIZE(inputBuffer),
		ImGuiInputTextFlags_EscapeClearsAll)) {
	Refresh();
}
auto& imeIntegration = SimpleIME::SimpleImeIntegration::GetSingleton();
if (ImGui::IsItemActivated()) {
	imeIntegration.EnableIme(true);
	imeIntegration.UpdateImeWindowPosition();
} else if (ImGui::IsItemDeactivated()) {
	imeIntegration.EnableIme(false);
}
```

The main code stored in `SimpleIME::SimpleImeIntegration` class:

```c++
namespace SimpleIME
{
	enum class SkseImeMessage
	{
		IME_INTEGRATION_INIT = 0x100,
		IME_COMPOSITION_RESULT,
	};

	struct SIMPLE_API IntegrationData
	{
		// Other mod must call this to render IME window
		void (*RenderIme)() = nullptr;
		// enable IME for other mod
		bool (*EnableIme)(bool enable) = nullptr;
		// update IME window position (the candidate and composition window)
		void (*UpdateImeWindowPosition)(float posX, float posY) = nullptr;
	};

	static_assert(sizeof(IntegrationData) == 24);

	class SimpleImeIntegration
	{
		using Message = SKSE::MessagingInterface::Message;

	public:
		enum ImeMessage : std::uint32_t
		{
			IME_INTEGRATION_INIT = 0x100,
			IME_COMPOSITION_RESULT,
		};

		static auto HandleMessage(Message* a_msg) -> void;

		auto EnableIme(bool enable) -> bool;
		auto RenderIme() -> void;
		auto UpdateImeWindowPosition(float posX, float posY) -> void;
		// Update IME window position by last ImGui item position
		auto UpdateImeWindowPosition() -> void;

		auto IsEnabled() -> bool
		{
			return isEnabled.load();
		}

		static auto GetSingleton() -> SimpleImeIntegration&
		{
			static SimpleImeIntegration g_instance;
			return g_instance;
		}

	private:
		std::atomic_bool isIntegrated = false;
		std::atomic_bool isEnabled = false;
		IntegrationData* integrationData = nullptr;

		auto OnMessageImeIntegrationInit(Message* a_msg) -> void;
		auto OnMessageImeCompositionResult(Message* a_msg) -> void;
	};
}
```

For IME support in other ImGui InputText widgets, the decision would be up to you, or you could make modifications in your own branch.

A demo:

![image](https://i.imgur.com/fHwnYTO.png)

And, the SimpleIME main code in [JamieMods-SimpleIME](https://github.com/cyfewlp/JamieMods/tree/feature-modex)

Finally, I’m thrilled to support an exceptional mod like Modex.😊



