### PR TITLE
Patchu1i/issue68

### DIFF
--- a/src/include/T/Table.h
+++ b/src/include/T/Table.h
@@ -34,7 +34,8 @@ namespace Modex
             ModexTableFlag_EnableNonPlayableSort = 1 << 3,
             ModexTableFlag_EnableUniqueSort = 1 << 4,
             ModexTableFlag_EnableEssentialSort = 1 << 5,
-            ModexTableFlag_EnablePluginKitView = 1 << 6
+            ModexTableFlag_EnablePluginKitView = 1 << 6,
+            ModexTableFlag_EnableDisabledSort = 1 << 7
         };
 
         enum DragBehavior {
@@ -73,6 +74,7 @@ namespace Modex
 
             this->hideEnchanted = false;
             this->hideNonPlayable = true;
+            this->hideDisabled = false;
             this->compactView = false;
             this->showEditorID = false;
             this->itemPreview = nullptr;
@@ -196,6 +198,7 @@ namespace Modex
         bool                    hideNonPlayable;
         bool                    hideNonUnique;
         bool                    hideNonEssential;
+        bool                    hideDisabled;
         bool                    compactView;
         bool                    showEditorID;
         bool                    showPluginKitView;

--- a/src/include/U/Util.h
+++ b/src/include/U/Util.h
@@ -680,6 +680,7 @@ namespace Utils
 		{ "SPELL", ICON_LC_WAND },
 		{ "UNIQUE", ICON_LC_GEM },
 		{ "ESSENTIAL", ICON_LC_SHIELD_ALERT },
+		{ "DISABLED", ICON_LC_CIRCLE_X },
 
 		// ObjectData
 		{ "CONTAINER", ICON_LC_PACKAGE },

--- a/src/windows/NPC/NPC.cpp
+++ b/src/windows/NPC/NPC.cpp
@@ -122,6 +122,7 @@ namespace Modex
 		tableView.SetGenerator([]() { return Data::GetSingleton()->GetNPCList(); });
 		tableView.AddFlag(TableView<NPCData>::ModexTableFlag_EnableUniqueSort);
 		tableView.AddFlag(TableView<NPCData>::ModexTableFlag_EnableEssentialSort);
+		tableView.AddFlag(TableView<NPCData>::ModexTableFlag_EnableDisabledSort);
 		tableView.SetupSearch(Data::PLUGIN_TYPE::NPC);
 		tableView.SetClickAmount(&clickToPlaceCount);
 		tableView.Init();


### PR DESCRIPTION
Fixes #68

- Added Enable/Disable context item to NPC's.
- Added Icon to display NPC Disabled status.
- Added toggleable option to hide Enabled (Non-Disabled) NPC's. Allowing for quick reference to disabled NPC's in ones game.

I didn't touch behavior regarding teleporting/interacting with NPC's that are disabled in the menu. I may extend the Modex UI Notification system to employ a message when trying to interact/interface with a disabled NPC. For now, didn't want to touch it because I expect users reporting non-issues.