### PR TITLE
feat: recent and favorite persistent cell userdata

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -464,6 +464,23 @@ namespace Modex
 		}
 	}
 
+	CellData& Data::GetCellByEditorID(const std::string& a_editorid)
+	{
+		for (auto& cell : _cellCache) {
+			if (cell.GetEditorID() == a_editorid) {
+				return cell;
+			}
+		}
+
+		return _cellCache.emplace_back(
+			"MODEX_ERR",
+			"MODEX_ERR",
+			"MODEX_ERR",
+			"MODEX_ERR",
+			a_editorid,
+			nullptr);
+	}
+
 	void Data::Run()
 	{
 		Settings::Config& config = Settings::GetSingleton()->GetConfig();

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -472,13 +472,15 @@ namespace Modex
 			}
 		}
 
-		return _cellCache.emplace_back(
+		static CellData emptyCell(
 			"MODEX_ERR",
 			"MODEX_ERR",
 			"MODEX_ERR",
 			"MODEX_ERR",
-			a_editorid,
+			"MODEX_ERR",
 			nullptr);
+		logger::error("[Data] Cell with editor ID '{}' not found.", a_editorid);
+		return emptyCell;
 	}
 
 	void Data::Run()

--- a/src/include/D/Data.h
+++ b/src/include/D/Data.h
@@ -76,11 +76,13 @@ namespace Modex
 		[[nodiscard]] inline std::set<std::string> 		GetNPCClassList() 	{ return _npcClassList; 	}
 		[[nodiscard]] inline std::set<std::string> 		GetNPCRaceList() 	{ return _npcRaceList; 		}
 		[[nodiscard]] inline std::set<std::string> 		GetNPCFactionList() { return _npcFactionList; 	}
+		[[nodiscard]] CellData& 					GetCellByEditorID(const std::string& a_editorid);
 
 		void 											GenerateItemList();
 		void 											GenerateNPCList();
 		void 											GenerateObjectList();
 		void 											GenerateCellList();
+
 
 		void SortAddItemList();
 

--- a/src/include/P/Persistent.h
+++ b/src/include/P/Persistent.h
@@ -60,6 +60,48 @@ namespace Modex
 			GetSingleton()->m_userdata[a_key] = a_value;
 		}
 
+		static void AddCellToFavorite(const std::string& a_editorid)
+		{
+			auto& favorites = GetSingleton()->m_teleport_favorites;
+
+			// Check if the item is already in the list
+			for (const auto& favorite : favorites) {
+				if (favorite == a_editorid) {
+					return;  // Already in favorites, no need to add again
+				}
+			}
+
+			// If not found, add a new item to the front
+			favorites.emplace_front(a_editorid);
+		}
+
+		static void RemoveCellFromFavorite(const std::string& a_editorid)
+		{
+			auto& favorites = GetSingleton()->m_teleport_favorites;
+
+			// Find and remove the item from the list
+			for (auto it = favorites.begin(); it != favorites.end(); ++it) {
+				if (*it == a_editorid) {
+					favorites.erase(it);
+					return;  // Item found and removed
+				}
+			}
+		}
+
+		static bool IsCellFavorite(const std::string& a_editorid)
+		{
+			const auto& favorites = GetSingleton()->m_teleport_favorites;
+
+			// Check if the item is in the favorites list
+			for (const auto& favorite : favorites) {
+				if (favorite == a_editorid) {
+					return true;  // Item is a favorite
+				}
+			}
+
+			return false;  // Item not found in favorites
+		}
+
 		template <typename DataType>
 		static void AddRecentItem(const std::string& a_editorid, uint32_t a_refID)
 		{
@@ -71,8 +113,10 @@ namespace Modex
 				recently_used = &GetSingleton()->m_npc_recently_used;
 			} else if (std::is_same_v<DataType, ObjectData>) {
 				recently_used = &GetSingleton()->m_object_recently_used;
+			} else if (std::is_same_v<DataType, CellData>) {
+				recently_used = &GetSingleton()->m_teleport_recently_used;
 			} else {
-				return;
+				return;  // Unsupported type
 			}
 
 			if (recently_used == nullptr) {
@@ -105,8 +149,12 @@ namespace Modex
 				GetSingleton()->m_additem_recently_used.clear();
 			} else if (std::is_same_v<DataType, NPCData>) {
 				GetSingleton()->m_npc_recently_used.clear();
-			} else if (std::is_same_v<DataType, RE::TESObjectREFR>) {
+			} else if (std::is_same_v<DataType, ObjectData>) {
 				GetSingleton()->m_object_recently_used.clear();
+			} else if (std::is_same_v<DataType, CellData>) {
+				GetSingleton()->m_teleport_recently_used.clear();
+			} else {
+				return;  // Unsupported type
 			}
 		}
 
@@ -123,6 +171,8 @@ namespace Modex
 				recently_used = &GetSingleton()->m_npc_recently_used;
 			} else if (std::is_same_v<DataType, ObjectData>) {
 				recently_used = &GetSingleton()->m_object_recently_used;
+			} else if (std::is_same_v<DataType, CellData>) {
+				recently_used = &GetSingleton()->m_teleport_recently_used;
 			} else {
 				return;
 			}
@@ -135,6 +185,18 @@ namespace Modex
 
 			for (const auto& pair : *recently_used) {
 				a_out.push_back(pair);
+			}
+		}
+
+		// Can set this up as a template function for additional types in the future.
+		static void GetFavoriteItems(std::list<std::string>& a_out)
+		{
+			auto& favorites = GetSingleton()->m_teleport_favorites;
+
+			a_out.clear();
+			
+			for (const auto& favorite : favorites) {
+				a_out.push_back(favorite);
 			}
 		}
 
@@ -179,6 +241,8 @@ namespace Modex
 		std::list<std::pair<std::string, std::uint32_t>> m_additem_recently_used;
 		std::list<std::pair<std::string, std::uint32_t>> m_npc_recently_used;
 		std::list<std::pair<std::string, std::uint32_t>> m_object_recently_used;
+		std::list<std::pair<std::string, std::uint32_t>> m_teleport_recently_used;
+		std::list<std::string> m_teleport_favorites;
 
 		const std::string json_user_path = "Data/Interface/Modex/User/";
 	};

--- a/src/include/T/Teleport.h
+++ b/src/include/T/Teleport.h
@@ -51,7 +51,6 @@ namespace Modex
 		void			Unload();
 		void			Load();
 		void 			Refresh();
-		void 			DrawWorldMap();
 
 	private:
 		void 			ApplyFilters();

--- a/src/include/T/Teleport.h
+++ b/src/include/T/Teleport.h
@@ -51,6 +51,7 @@ namespace Modex
 		void			Unload();
 		void			Load();
 		void 			Refresh();
+		void 			DrawWorldMap();
 
 	private:
 		void 			ApplyFilters();
@@ -58,6 +59,12 @@ namespace Modex
 		void 			ShowSearch();
 		void 			ShowFormTable();
 		void 			ShowTeleportContextMenu(CellData& a_cell);
+
+		void 			RemoveCellFromFavorite(const std::string& a_editorid);
+		void 			AddCellToFavorite(const std::string& a_editorid);
+		void 			AddCellToRecent(const std::string& a_editorid);
+		void 			LoadRecentCells();
+		void 			LoadFavoriteCells();
 
 		// Local State Variables.
 		bool 						b_ClickToTeleport;
@@ -96,5 +103,12 @@ namespace Modex
 		// ISearch Interface
 		char 						modSearchBuffer[256];
 		std::string 				selectedMod;
+
+		// Recent/Favorite List
+		std::string 				hoveredCellEditorID;
+		bool 						refreshFavoriteList;
+		bool 						refreshRecentList;
+		std::vector<std::unique_ptr<CellData>> recentList;
+		std::list<std::string> favoriteList;
 	};
 }

--- a/src/include/U/Util.h
+++ b/src/include/U/Util.h
@@ -690,7 +690,12 @@ namespace Utils
 		{ "FURNITURE", ICON_LC_ARMCHAIR },
 		{ "ACTIVATOR", ICON_LC_TARGET },
 		{ "TREE", ICON_LC_TREE_PINE },
-		{ "FLOWER", ICON_LC_FLOWER }
+		{ "FLOWER", ICON_LC_FLOWER },
+
+		// CellData
+		{ "LAND", ICON_LC_MAP }, // plugin
+		{ "CELL", ICON_LC_MAP_PIN },
+
 	};
 
 	static inline std::string GetFormTypeIcon(const RE::FormType& a_type)

--- a/src/windows/Persistent.cpp
+++ b/src/windows/Persistent.cpp
@@ -111,6 +111,14 @@ namespace Modex
 		for (auto& [key, value] : JSON["Userdata"]["Recently Used (Object)"].items()) {
 			m_object_recently_used.emplace_back(key, value.get<uint32_t>());
 		}
+
+		for (auto& [key, value] : JSON["Userdata"]["Recently Used (Teleport)"].items()) {
+			m_teleport_recently_used.emplace_back(key, value.get<uint32_t>());
+		}
+
+		for (auto& cell : JSON["Userdata"]["Favorite Cells"]) {
+			m_teleport_favorites.emplace_back(cell.get<std::string>());
+		}
 	}
 
 	void PersistentData::SaveUserdata()
@@ -135,19 +143,26 @@ namespace Modex
 		JSON["Userdata"]["Recently Used (AddItem)"] = nlohmann::json::object();
 		for (const auto& pair : m_additem_recently_used) {
 			JSON["Userdata"]["Recently Used (AddItem)"][pair.first] = pair.second;
-			// JSON["Userdata"]["Recently Used (AddItem)"].push_back(item);
 		}
 
 		JSON["Userdata"]["Recently Used (NPC)"] = nlohmann::json::object();
 		for (const auto& pair : m_npc_recently_used) {
 			JSON["Userdata"]["Recently Used (NPC)"][pair.first] = pair.second;
-			// JSON["Userdata"]["Recently Used (NPC)"].push_back(npc);
 		}
 
 		JSON["Userdata"]["Recently Used (Object)"] = nlohmann::json::object();
 		for (const auto& pair : m_object_recently_used) {
 			JSON["Userdata"]["Recently Used (Object)"][pair.first] = pair.second;
-			// JSON["Userdata"]["Recently Used (Object)"].push_back(object);
+		}
+
+		JSON["Userdata"]["Recently Used (Teleport)"] = nlohmann::json::object();
+		for (const auto& pair : m_teleport_recently_used) {
+			JSON["Userdata"]["Recently Used (Teleport)"][pair.first] = pair.second;
+		}
+
+		JSON["Userdata"]["Favorite Cells"] = nlohmann::json::array();
+		for (const auto& cell : m_teleport_favorites) {
+			JSON["Userdata"]["Favorite Cells"].push_back(cell);
 		}
 
 		if (!SaveJSONFile(json_user_path + "userdata.json", JSON)) {

--- a/src/windows/Persistent.cpp
+++ b/src/windows/Persistent.cpp
@@ -112,12 +112,16 @@ namespace Modex
 			m_object_recently_used.emplace_back(key, value.get<uint32_t>());
 		}
 
-		for (auto& [key, value] : JSON["Userdata"]["Recently Used (Teleport)"].items()) {
-			m_teleport_recently_used.emplace_back(key, value.get<uint32_t>());
+		if (JSON["Userdata"].contains("Recently Used (Teleport)")) {
+			for (auto& [key, value] : JSON["Userdata"]["Recently Used (Teleport)"].items()) {
+				m_teleport_recently_used.emplace_back(key, value.get<uint32_t>());
+			}
 		}
 
-		for (auto& cell : JSON["Userdata"]["Favorite Cells"]) {
-			m_teleport_favorites.emplace_back(cell.get<std::string>());
+		if (JSON["Userdata"].contains("Favorite Cells")) {
+			for (auto& cell : JSON["Userdata"]["Favorite Cells"]) {
+				m_teleport_favorites.emplace_back(cell.get<std::string>());
+			}
 		}
 	}
 

--- a/src/windows/Teleport/Actions.cpp
+++ b/src/windows/Teleport/Actions.cpp
@@ -1,9 +1,59 @@
 #include "include/C/Console.h"
 #include "include/M/Menu.h"
 #include "include/T/Teleport.h"
+#include "include/U/Util.h"
 
 namespace Modex
 {
+	void TeleportWindow::AddCellToRecent(const std::string& a_editorid)
+	{
+		PersistentData::AddRecentItem<CellData>(a_editorid, 0);
+		this->refreshRecentList = true;
+	}
+
+	void TeleportWindow::AddCellToFavorite(const std::string& a_editorid)
+	{
+		PersistentData::GetSingleton()->AddCellToFavorite(a_editorid);
+		this->refreshFavoriteList = true;
+	}
+
+	void TeleportWindow::RemoveCellFromFavorite(const std::string& a_editorid)
+	{
+		PersistentData::GetSingleton()->RemoveCellFromFavorite(a_editorid);
+		this->refreshFavoriteList = true;
+	}
+
+	void TeleportWindow::LoadRecentCells()
+	{
+		std::vector<std::pair<std::string, std::uint32_t>> recentItems;
+		this->recentList.clear();
+
+		// Load recent items from PersistentData
+		PersistentData::GetSingleton()->GetRecentItems<CellData>(recentItems);
+
+		if (recentItems.empty()) {
+			return;
+		}
+
+		for (const auto& pair : recentItems) {
+			auto& cellData = Data::GetSingleton()->GetCellByEditorID(pair.first);
+
+			recentList.emplace_back(std::make_unique<CellData>(cellData));
+		}
+	}
+
+	void TeleportWindow::LoadFavoriteCells()
+	{
+		this->favoriteList.clear();
+
+		// Load favorite items from PersistentData
+		PersistentData::GetSingleton()->GetFavoriteItems(this->favoriteList);
+
+		if (this->favoriteList.empty()) {
+			return;
+		}
+	}
+
 	void TeleportWindow::ShowActions()
 	{
 		auto a_style = Settings::GetSingleton()->GetStyle();
@@ -22,33 +72,143 @@ namespace Modex
 
 		ImGui::PopStyleVar(2);
 
-		ImGui::Spacing();
-		ImGui::SubCategoryHeader(_T("Favorite"), ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+		ImGui::SubCategoryHeader(_T("Favorite"));
 
-		// ImGui::PushStyleVar(ImGuiStyleVar_ButtonTextAlign, ImVec2(0.5f, 0.5f));
+		auto constexpr flags = ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration |
+		                       ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing;
 
-		// auto constexpr flags = ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration |
-		//                        ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing;
+		// TODO: Need to style the buttons here, gradientbutton is not fitting.
+		bool showScrollArrow = false;
+		if (ImGui::BeginChild("##TeleportFavoriteScroll", ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y / 2.0f), false, flags)) {
+			for (auto& editorid : this->favoriteList) {
+				auto cell = Data::GetSingleton()->GetCellByEditorID(editorid);
+				ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, ImGui::GetFontSize() * 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 0.5f));
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+				ImGui::PushID(editorid.c_str());
+				if (ImGui::Selectable(cell.cellName.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAllColumns)) {
+					Console::Teleport(editorid);
+					Console::StartProcessThread();
+					this->AddCellToRecent(editorid);
 
-		// auto tempList = Data::GetSingleton()->GetTeleportList();
-		// if (ImGui::BeginChild("##TeleportFavoriteScroll", ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y - 10), false, flags)) {
-		// 	ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, 0));
-		// 	for (auto& cell : tempList) {
-		// 		if (cell.favorite) {
-		// 			if (ImGui::GradientButton(cell.GetEditorID().data(), ImVec2(ImGui::GetContentRegionAvail().x, 0))) {
-		// 				Console::Teleport(cell.GetEditorID().data());
-		// 				Console::StartProcessThread();
+					Menu::GetSingleton()->Close();
+				}
 
-		// 				Menu::GetSingleton()->Close();
-		// 				break;
-		// 			}
-		// 		}
-		// 	}
+				ImGui::PopStyleColor(1);
+				ImGui::PopStyleVar(2);
 
-		// 	ImGui::PopStyleVar(1);
-		// 	ImGui::EndChild();
-		// }
+				if (ImGui::IsItemHovered()) {
+					ImGui::BeginTooltip();
+					ImGui::Text("%s %s", Utils::IconMap["EDITORID"].c_str(), editorid.c_str());
+					ImGui::Text("%s %s", Utils::IconMap["CELL"].c_str(), cell.cellName.c_str());
+					ImGui::Text("%s %s", Utils::IconMap["LAND"].c_str(), cell.filename.c_str());
+					ImGui::EndTooltip();
+				}
 
-		// ImGui::PopStyleVar(1);
+				ImGui::PopID();
+
+				if (ImGui::IsItemClicked(ImGuiMouseButton_Middle)) {
+					PersistentData::GetSingleton()->RemoveCellFromFavorite(editorid);
+					this->refreshFavoriteList = true;
+				}
+
+				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+					ImGui::OpenPopup("##ShowTeleportContextMenu2");
+					this->hoveredCellEditorID = editorid;
+				}
+			}
+
+			if (ImGui::BeginPopup("##ShowTeleportContextMenu2")) {
+				if (auto cell = &Data::GetSingleton()->GetCellByEditorID(this->hoveredCellEditorID)) {
+					this->ShowTeleportContextMenu(*cell);
+				}
+
+				ImGui::EndPopup();
+			}
+
+			if (ImGui::GetScrollY() < ImGui::GetScrollMaxY()) {
+				showScrollArrow = true;
+			}
+
+			ImGui::EndChild();
+		}
+
+		if (this->favoriteList.size() * ImGui::GetFontSize() > (ImGui::GetContentRegionAvail().y / 2.0f)) {
+			if (showScrollArrow) {
+				auto drawList = ImGui::GetWindowDrawList();
+				const float arrowSize = ImGui::GetFontSize();
+				ImVec2 pos = ImGui::GetCursorScreenPos() - ImVec2(0, arrowSize + ImGui::GetStyle().ItemSpacing.y);
+				ImVec2 size = ImVec2(ImGui::GetContentRegionAvail().x, arrowSize);
+				drawList->AddText(pos, ImGui::GetColorU32(ImGuiCol_Text), ICON_LC_ARROW_DOWN);
+				drawList->AddText(pos + ImVec2(size.x - arrowSize, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ICON_LC_ARROW_DOWN);
+			}
+		}
+
+		ImGui::SubCategoryHeader(_T("Recent"));
+
+		if (ImGui::BeginChild("##TeleportRecentScroll", ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y), false, flags)) {
+			for (const auto& cell : this->recentList) {
+				const auto& editorid = cell.get()->editorid;
+				ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(0, ImGui::GetFontSize() * 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_SelectableTextAlign, ImVec2(0.5f, 0.5f));
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.0f, 0.0f, 0.0f, 0.0f));
+				ImGui::PushID(editorid.c_str());
+				if (ImGui::Selectable(cell.get()->cellName.c_str(), false, ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_SpanAllColumns)) {
+					Console::Teleport(editorid);
+					Console::StartProcessThread();
+					this->AddCellToRecent(editorid);
+
+					Menu::GetSingleton()->Close();
+				}
+
+				ImGui::PopStyleColor(1);
+				ImGui::PopStyleVar(2);
+
+				if (ImGui::IsItemHovered()) {
+					ImGui::BeginTooltip();
+					ImGui::Text("%s %s", Utils::IconMap["EDITORID"].c_str(), editorid.c_str());
+					ImGui::Text("%s %s", Utils::IconMap["CELL"].c_str(), cell.get()->cellName.c_str());
+					ImGui::Text("%s %s", Utils::IconMap["LAND"].c_str(), cell.get()->filename.c_str());
+					ImGui::EndTooltip();
+				}
+
+				ImGui::PopID();
+
+				if (ImGui::IsItemClicked(ImGuiMouseButton_Middle)) {
+					PersistentData::GetSingleton()->RemoveCellFromFavorite(editorid);
+					this->refreshFavoriteList = true;
+				}
+
+				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
+					ImGui::OpenPopup("##ShowTeleportContextMenu2");
+					this->hoveredCellEditorID = editorid;
+				}
+			}
+
+			if (ImGui::BeginPopup("##ShowTeleportContextMenu2")) {
+				if (auto cell = &Data::GetSingleton()->GetCellByEditorID(this->hoveredCellEditorID)) {
+					this->ShowTeleportContextMenu(*cell);
+				}
+
+				ImGui::EndPopup();
+			}
+
+			if (ImGui::GetScrollY() < ImGui::GetScrollMaxY()) {
+				showScrollArrow = true;
+			}
+
+			ImGui::EndChild();
+		}
+
+		if (this->recentList.size() * ImGui::GetFontSize() > (ImGui::GetContentRegionAvail().y)) {
+			if (showScrollArrow) {
+				auto drawList = ImGui::GetWindowDrawList();
+				const float arrowSize = ImGui::GetFontSize();
+				ImVec2 pos = ImGui::GetCursorScreenPos() - ImVec2(0, arrowSize + ImGui::GetStyle().ItemSpacing.y);
+				ImVec2 size = ImVec2(ImGui::GetContentRegionAvail().x, arrowSize);
+				drawList->AddText(pos, ImGui::GetColorU32(ImGuiCol_Text), ICON_LC_ARROW_DOWN);
+				drawList->AddText(pos + ImVec2(size.x - arrowSize, 0.0f), ImGui::GetColorU32(ImGuiCol_Text), ICON_LC_ARROW_DOWN);
+			}
+		}
 	}
 }

--- a/src/windows/Teleport/Actions.cpp
+++ b/src/windows/Teleport/Actions.cpp
@@ -27,7 +27,6 @@ namespace Modex
 	{
 		std::vector<std::pair<std::string, std::uint32_t>> recentItems;
 		this->recentList.clear();
-		this->recentList.reserve(recentItems.size());  // TODO: Use configurable size.
 
 		// Load recent items from PersistentData
 		PersistentData::GetSingleton()->GetRecentItems<CellData>(recentItems);
@@ -35,6 +34,8 @@ namespace Modex
 		if (recentItems.empty()) {
 			return;
 		}
+
+		this->recentList.reserve(recentItems.size());  // TODO: Use configurable size.
 
 		for (const auto& pair : recentItems) {
 			auto& cellData = Data::GetSingleton()->GetCellByEditorID(pair.first);

--- a/src/windows/Teleport/Actions.cpp
+++ b/src/windows/Teleport/Actions.cpp
@@ -77,7 +77,6 @@ namespace Modex
 		auto constexpr flags = ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration |
 		                       ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing;
 
-		// TODO: Need to style the buttons here, gradientbutton is not fitting.
 		bool showScrollArrow = false;
 		if (ImGui::BeginChild("##TeleportFavoriteScroll", ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y / 2.0f), false, flags)) {
 			for (auto& editorid : this->favoriteList) {
@@ -107,10 +106,7 @@ namespace Modex
 
 				ImGui::PopID();
 
-				if (ImGui::IsItemClicked(ImGuiMouseButton_Middle)) {
-					PersistentData::GetSingleton()->RemoveCellFromFavorite(editorid);
-					this->refreshFavoriteList = true;
-				}
+				// Remove middle-click handler for recent items as it doesn't apply here
 
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
 					ImGui::OpenPopup("##ShowTeleportContextMenu2");
@@ -146,6 +142,7 @@ namespace Modex
 
 		ImGui::SubCategoryHeader(_T("Recent"));
 
+		showScrollArrow = false;
 		if (ImGui::BeginChild("##TeleportRecentScroll", ImVec2(ImGui::GetContentRegionAvail().x, ImGui::GetContentRegionAvail().y), false, flags)) {
 			for (const auto& cell : this->recentList) {
 				const auto& editorid = cell.get()->editorid;

--- a/src/windows/Teleport/Actions.cpp
+++ b/src/windows/Teleport/Actions.cpp
@@ -27,6 +27,7 @@ namespace Modex
 	{
 		std::vector<std::pair<std::string, std::uint32_t>> recentItems;
 		this->recentList.clear();
+		this->recentList.reserve(recentItems.size());  // TODO: Use configurable size.
 
 		// Load recent items from PersistentData
 		PersistentData::GetSingleton()->GetRecentItems<CellData>(recentItems);
@@ -109,12 +110,12 @@ namespace Modex
 				// Remove middle-click handler for recent items as it doesn't apply here
 
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
-					ImGui::OpenPopup("##ShowTeleportContextMenu2");
+					ImGui::OpenPopup("##Teleport::Favorite::ContextMenu");
 					this->hoveredCellEditorID = editorid;
 				}
 			}
 
-			if (ImGui::BeginPopup("##ShowTeleportContextMenu2")) {
+			if (ImGui::BeginPopup("##Teleport::Favorite::ContextMenu")) {
 				if (auto cell = &Data::GetSingleton()->GetCellByEditorID(this->hoveredCellEditorID)) {
 					this->ShowTeleportContextMenu(*cell);
 				}
@@ -177,12 +178,12 @@ namespace Modex
 				}
 
 				if (ImGui::IsItemClicked(ImGuiMouseButton_Right)) {
-					ImGui::OpenPopup("##ShowTeleportContextMenu2");
+					ImGui::OpenPopup("##Teleport::Recent::ContextMenu");
 					this->hoveredCellEditorID = editorid;
 				}
 			}
 
-			if (ImGui::BeginPopup("##ShowTeleportContextMenu2")) {
+			if (ImGui::BeginPopup("##Teleport::Recent::ContextMenu")) {
 				if (auto cell = &Data::GetSingleton()->GetCellByEditorID(this->hoveredCellEditorID)) {
 					this->ShowTeleportContextMenu(*cell);
 				}

--- a/src/windows/Teleport/Table.cpp
+++ b/src/windows/Teleport/Table.cpp
@@ -13,6 +13,29 @@ namespace Modex
 
 		ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
 
+		bool is_favorite = PersistentData::IsCellFavorite(a_cell.editorid);
+
+		if (is_favorite) {
+			if (ImGui::Selectable(_T("FAVORITE_REMOVE"), false, flags)) {
+				this->RemoveCellFromFavorite(a_cell.editorid);
+				ImGui::CloseCurrentPopup();
+			}
+		} else {
+			if (ImGui::Selectable(_T("FAVORITE_ADD"), false, flags)) {
+				this->AddCellToFavorite(a_cell.editorid);
+				ImGui::CloseCurrentPopup();
+			}
+		}
+
+		if (ImGui::Selectable(_T("Teleport"), false, flags)) {
+			Console::Teleport(a_cell.editorid);
+			Console::StartProcessThread();
+			this->AddCellToRecent(a_cell.editorid);
+			ImGui::CloseCurrentPopup();
+		}
+
+		ImGui::SeparatorEx(ImGuiSeparatorFlags_Horizontal);
+
 		if (ImGui::Selectable(_T("GENERAL_COPY_WORLDSPACE_NAME"), false, flags)) {
 			ImGui::LogToClipboard();
 			ImGui::LogText(a_cell.space.c_str());
@@ -152,6 +175,7 @@ namespace Modex
 							if (selectedCell != nullptr) {
 								Console::Teleport(selectedCell->editorid);
 								Console::StartProcessThread();
+								this->AddCellToRecent(selectedCell->editorid);
 								Menu::GetSingleton()->Close();
 							}
 						}
@@ -167,6 +191,16 @@ namespace Modex
 			}
 
 			ImGui::EndTable();
+
+			if (this->refreshRecentList) {
+				this->LoadRecentCells();
+				this->refreshRecentList = false;
+			}
+
+			if (this->refreshFavoriteList) {
+				this->LoadFavoriteCells();
+				this->refreshFavoriteList = false;
+			}
 		}
 	}
 }

--- a/src/windows/Teleport/Teleport.cpp
+++ b/src/windows/Teleport/Teleport.cpp
@@ -101,5 +101,11 @@ namespace Modex
 		if (is_default) {
 			this->Refresh();
 		}
+
+		this->refreshRecentList = false;
+		this->refreshFavoriteList = false;
+
+		this->LoadRecentCells();
+		this->LoadFavoriteCells();
 	}
 }


### PR DESCRIPTION
Adds recently used cells, and favorite cells to the action bar of the module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to mark teleport locations (cells) as favorites and manage a list of favorite cells.
  - Introduced tracking of recently used teleport locations for quick access.
  - Favorites and recent teleport locations are now displayed in dedicated scrollable lists within the teleport window, with options to add, remove, and teleport directly from the lists.
  - User favorites and recent teleport locations are saved and loaded automatically.
  - Teleporting to a cell adds it to the recent list automatically.
  - Added retrieval of cells by editor ID with error fallback for missing cells.

- **User Interface**
  - Enhanced context menus for teleport cells, allowing users to add or remove favorites and teleport directly.
  - Improved tooltips and context actions for favorite and recent cell lists.
  - Added scroll arrows and refined UI styling for favorite and recent teleport lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->